### PR TITLE
Add license headers

### DIFF
--- a/ember_csi/cl_crd.py
+++ b/ember_csi/cl_crd.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2018, Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 """CRD metadata persistence plugin
 
 The identifier for this plugin when using it in the X_CSI_PERSISTENCE_CONFIG

--- a/ember_csi/csi_types.py
+++ b/ember_csi/csi_types.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2018, Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 import csi_pb2
 
 

--- a/ember_csi/ember_csi.py
+++ b/ember_csi/ember_csi.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python
+# Copyright (c) 2018, Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 
 # Supports CSI v0.2.0
 # TODO(geguileo): Check that all parameters are present on received RPC calls


### PR DESCRIPTION
Python code was missing license headers.  Add Apache license headers to
Python files that have code and have not automatically generated by the
gRPC Python protocol compiler plugin.