### PR TITLE
Use embercsi docker images

### DIFF
--- a/examples/docker/rbd.sh
+++ b/examples/docker/rbd.sh
@@ -5,4 +5,4 @@ docker run --env-file rbd -t --privileged --net=host \
     -v `realpath ../../tmp`:/var/lib/cinder  \
     -v `realpath ./ceph.conf`:/etc/ceph/ceph.conf \
     -v `realpath ./ceph.client.cinder.keyring`:/etc/ceph/ceph.client.cinder.keyring \
-    -p 50051:50051 -p 4444:4444 --name=ember-csi --rm=true akrog/ember-csi
+    -p 50051:50051 -p 4444:4444 --name=ember-csi --rm=true embercsi/ember-csi

--- a/examples/docker/xtremio.sh
+++ b/examples/docker/xtremio.sh
@@ -4,4 +4,4 @@ docker run --env-file xtremio -t --privileged --net=host \
     -v /dev:/dev \
     -v `realpath ../../tmp/mnt`:/mnt \
     -v `realpath ../../tmp`:/var/lib/cinder \
-    -p 50051:50051 -p 4444:4444 --name=ember-csi --rm=true akrog/ember-csi
+    -p 50051:50051 -p 4444:4444 --name=ember-csi --rm=true embercsi/ember-csi

--- a/examples/kubernetes/kubeyml/controller.yml
+++ b/examples/kubernetes/kubeyml/controller.yml
@@ -94,7 +94,7 @@ spec:
         - mountPath: /csi-data
           name: socket-dir
       - name: csi-driver
-        image: akrog/ember-csi:master
+        image: embercsi/ember-csi:master
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/examples/kubernetes/kubeyml/node.yml
+++ b/examples/kubernetes/kubeyml/node.yml
@@ -75,7 +75,7 @@ spec:
           - mountPath: /csi-data
             name: socket-dir
         - name: csi-driver
-          image: akrog/ember-csi:master
+          image: embercsi/ember-csi:master
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true

--- a/examples/kubevirt/csi.yml
+++ b/examples/kubevirt/csi.yml
@@ -69,7 +69,7 @@ spec:
       value: '{"storage":"crd"}'
     - name: X_CSI_BACKEND_CONFIG
       value: '{"volume_backend_name":"xtremio","volume_driver":"cinder.volume.drivers.dell_emc.xtremio.XtremIOISCSIDriver","san_ip":"192.168.1.2","xtremio_cluster_name":"cluster-name","san_login":"user","san_password":"toomanysecrets"}'
-    image: akrog/ember-csi:master
+    image: embercsi/ember-csi:master
     imagePullPolicy: Always
     securityContext:
       privileged: true
@@ -96,7 +96,7 @@ spec:
       mountPropagation: Bidirectional
       name: modules-dir
   - name: csc
-    image: akrog/csc:v0.2.0
+    image: embercsi/csc:v0.2.0
     imagePullPolicy: IfNotPresent
     command: ["tail"]
     args: ["-f", "/dev/null"]


### PR DESCRIPTION
Now that we are automatically building images on embercsi/ember-csi we can stop using akrog/ember-csi for our examples.