### PR TITLE
Fix #45: Versions not being logged

### DIFF
--- a/ember_csi/ember_csi.py
+++ b/ember_csi/ember_csi.py
@@ -38,11 +38,6 @@ def main():
     server_class = _get_csi_server_class(class_name=config.MODE.title())
     copy_system_files()
 
-    LOG.info('Starting Ember CSI v%s with %d workers (cinder: v%s, '
-             'CSI spec: v%s)' %
-             (constants.VENDOR_VERSION, config.WORKERS,
-              constants.CINDER_VERSION, config.CSI_SPEC))
-
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=config.WORKERS))
     workarounds.grpc_eventlet(server)
@@ -52,6 +47,10 @@ def main():
                               ember_config=config.EMBER_CONFIG,
                               storage_nw_ip=config.STORAGE_NW_IP,
                               node_id=config.NODE_ID)
+
+    LOG.info('Ember CSI v%s with %d workers (cinder: v%s, CSI spec: v%s)' %
+             (constants.VENDOR_VERSION, config.WORKERS,
+              constants.CINDER_VERSION, config.CSI_SPEC))
 
     LOG.info('Persistence module: %s' % type(csi_plugin.persistence).__name__)
     msg = 'Running as %s' % config.MODE


### PR DESCRIPTION
We are looging the versions before we initialize the logging mechanism,
which means that we are not actually logging anything.

This patch changes the order of the versions logging after we have
actually configured it.