### PR TITLE
Fix CI requirements

### DIFF
--- a/ci-automation/requirements.txt
+++ b/ci-automation/requirements.txt
@@ -5,3 +5,4 @@ decorator
 grpcio==1.15.0
 pyyaml
 ipaddress
+cinderlib


### PR DESCRIPTION
On commit 6f8212c0c887491f2c10e4bf0197ab487f99c8f3 we removed the
cinderlib library from the requirements as they will be coming from the
Cinder respository.

This broke the CI that was depending on it.

Add the cinderlib requirement to the CI requirements.txt file to solve
this issue.