### PR TITLE
TEST env pod with unique name

### DIFF
--- a/ci-automation/config/ember-csi-template.yaml
+++ b/ci-automation/config/ember-csi-template.yaml
@@ -1,12 +1,18 @@
-kind: List
-items:
+apiVersion: v1
+kind: Template
+metadata:
+  name: ember-csi
+parameters:
+  - name:         PODNAME
+    Display Name: pod name
+    Description:  TEST environment pod name
+    Required:     true
+    Value:        "ember-csi"
+objects:
   - apiVersion: "v1"
     kind: "Pod"
     metadata:
-      generateName: ember-csi-1-
-      labels:
-        app: ember-csi
-        env: test
+      name: ${PODNAME}
     spec:
       containers:
         - name: ember-csi


### PR DESCRIPTION
TEST environment name is now a unique name. Using the same uuid used for the HDSL pod name for the TEST env pod name. 

The CI now supports multiple PRs in parallel.

Replaced the pod manifest file with a template manifest file for a pod, where the name of the pod is a parameter.

Refactored Jenkisfile to use the Openshift Client plugin as much as possible.
Tried to replace the exec function with no avail. Filed an issue here:
https://github.com/openshift/jenkins-client-plugin/issues/215

@Akrog please review