### PR TITLE
Close #55: Use state_path in Ember cfg options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,10 @@ test-all: ## run tests on every Python version with tox
 	tox
 
 centos-bm-lvm:
+	mkdir -p /tmp/{locks,vols} && \
 	X_CSI_PERSISTENCE_CONFIG='{"storage":"memory"}' \
 	X_CSI_BACKEND_CONFIG='{"target_protocol":"iscsi","iscsi_ip_address":"127.0.0.1","volume_backend_name":"lvm","volume_driver":"cinder.volume.drivers.lvm.LVMVolumeDriver","volume_group":"ember-volumes","target_helper":"lioadm"}' \
-	X_CSI_EMBER_CONFIG='{"project_id":"io.ember-csi","user_id":"io.ember-csi","root_helper":"sudo","disable_logs":false,"debug":true,"request_multipath":false,"file_locks_path":"/tmp"}' \
+	X_CSI_EMBER_CONFIG='{"project_id":"io.ember-csi","user_id":"io.ember-csi","root_helper":"sudo","disable_logs":false,"debug":true,"request_multipath":false,"state_path":"/tmp"}' \
 	travis-scripts/run-bm-sanity.sh
 
 centos-lvm:

--- a/ember_csi/config.py
+++ b/ember_csi/config.py
@@ -24,6 +24,7 @@ import socket
 
 from oslo_context import context as context_utils
 from oslo_log import log as logging
+import six
 
 from ember_csi import constants
 from ember_csi import defaults
@@ -122,7 +123,24 @@ def validate():
     # Store version in x.y.z formatted string
     CSI_SPEC = spec_version
 
+    _set_defaults_ember_cfg()
     _set_topology_config()
+
+
+def _set_defaults_ember_cfg():
+    # First set defaults for missing keys
+    for key, value in defaults.EMBER_CFG.items():
+        EMBER_CONFIG.setdefault(key, value)
+
+    # Now convert $state_path
+    state_path = EMBER_CONFIG['state_path']
+    for key, value in EMBER_CONFIG.items():
+        if isinstance(value, six.string_types) and '$state_path' in value:
+            EMBER_CONFIG[key] = value.replace('$state_path', state_path)
+
+            EMBER_CONFIG[key] = value.replace('$state_path', state_path)
+    defaults.VOL_BINDS_DIR = defaults.VOL_BINDS_DIR.replace('$state_path',
+                                                            state_path)
 
 
 def _set_logging_config():

--- a/ember_csi/defaults.py
+++ b/ember_csi/defaults.py
@@ -19,8 +19,8 @@ MODE = 'all'
 PERSISTENCE_CFG = {'storage': 'crd', 'namespace': 'default'}
 ROOT_HELPER = 'sudo'
 STATE_PATH = '/var/lib/ember-csi'
-VOL_BINDS_DIR = STATE_PATH + '/vols'
-LOCKS_DIR = STATE_PATH + '/locks'
+VOL_BINDS_DIR = '$state_path/vols'
+LOCKS_DIR = '$state_path/locks'
 REQUEST_MULTIPATH = False
 EMBER_CFG = {'project_id': NAME, 'user_id': NAME, 'plugin_name': NAME,
              'root_helper': ROOT_HELPER,


### PR DESCRIPTION
This patch makes the locks and private volumes directories use provided
state_lock configuration passed on the config.

It also sets automatically any missing EMBER_CONFIG key with our
defaults.