### PR TITLE
Fix #58: Container is broken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cinderlib>=0.3.1
-grpcio>=1.12.0
+grpcio==1.12.0
 protobuf>=3.5.0.post1
-kubernetes>=7.0.0
-setuptools>=40.0.0
+kubernetes==7.0.0
+setuptools==40.0.0

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,13 @@ with open('HISTORY.md') as history_file:
 requirements = [
     # Once we release cinderlib with cinder we must pin this one
     'cinder',
-    'grpcio>=1.12.0',
+    'grpcio==1.12.0',
     # GRPCIO v1.12.0 has broken dependencies, so we include them here
     'protobuf>=3.5.0.post1',
     # For the CRD persistent metadata plugin
-    'kubernetes>=7.0.0',
+    'kubernetes==7.0.0',
     # Needed because some Kubernetes dependencies use version in format of 4.*
-    'setuptools>=40.0.0',
+    'setuptools==40.0.0',
 ]
 
 dependency_links = [

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands=flake8 ember_csi
 
 [testenv]
 usedevelop=True
-install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} --process-dependency-links {opts} {packages}
+install_command = pip install {opts} {packages}
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/ember_csi
 deps= -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
On commit a362f95604728f542109ca057c32c6bce3f34061 we set less
restrictive requirements, which led us to install kubernetes v8.0.1,
requests v2.19.1 and urllib3 1.24.1 in our container.

This breaks, breaks as explaed in the requests repository:
https://github.com/requests/requests/issues/4673

So we reverts the "Set less restrictive requirements" commit and also
remove the contrainst in tox.ini since upstream forces kubernetes
v8.0.1.