### PR TITLE
Add rbd-nbd package to container

### DIFF
--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -10,7 +10,7 @@ ENV PYTHONUNBUFFERED=true
 
 RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-release lvm2 which && \
     yum -y install python2-pip python-devel gcc && \
-    yum -y install python-rbd ceph-common git && \
+    yum -y install python-rbd ceph-common rbd-nbd git && \
     # Need new setuptools version or we'll get "SyntaxError: '<' operator not allowed in environment markers" when installing Cinder
     pip install 'setuptools>=38.6.0' future && \
     yum -y install xfsprogs e2fsprogs btrfs-progs nmap-ncat && \
@@ -18,7 +18,7 @@ RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-
     # Shallow clone
     git clone --depth=1 'https://github.com/openstack/cinder.git' && \
     # Apply cinderlib patch
-    cd cinder && git fetch https://git.openstack.org/openstack/cinder refs/changes/69/620669/10 && git checkout FETCH_HEAD && cd .. && \
+    cd cinder && git fetch https://git.openstack.org/openstack/cinder refs/changes/69/620669/14 && git checkout FETCH_HEAD && cd .. && \
     pip install --no-cache-dir cinder/ && \
     mkdir -p /var/lib/ember-csi/{vols,locks} && \
     touch /var/lib/ember-csi/ssh_known_hosts && \


### PR DESCRIPTION
Now that cinderlib supports rbd-nbd to attach RBD volumes we should
include it in our containers, as it'd be the preferred connection tool
for RBD volumes to avoid feature support mismatch between the kernel
module and the Ceph cluster.

The Dockerfile includes it via the base cinderlib container image, and
this patch adds it to Dockerfile-master.

Closes: #63