### PR TITLE
Don't return volume size

### DIFF
--- a/ember_csi/v0_3_0/csi.py
+++ b/ember_csi/v0_3_0/csi.py
@@ -125,7 +125,6 @@ class Controller(base.TopologyBase, base.SnapshotBase, base.ControllerBase):
     def _convert_snapshot_type(self, snap):
         created_at = int(common.date_to_nano(snap.created_at))
         snapshot = types.Snapshot(
-            size_bytes=int(snap.volume_size * constants.GB),
             id=snap.id,
             source_volume_id=snap.volume_id,
             created_at=created_at,

--- a/ember_csi/v1_0_0/csi.py
+++ b/ember_csi/v1_0_0/csi.py
@@ -161,7 +161,6 @@ class Controller(base.TopologyBase, base.SnapshotBase, base.ControllerBase):
         creation_time.FromDatetime(created_at)
 
         snapshot = types.Snapshot(
-            size_bytes=int(snap.volume_size * constants.GB),
             snapshot_id=snap.id,
             source_volume_id=snap.volume_id,
             creation_time=creation_time,


### PR DESCRIPTION
We are returning a false value for Snapshots, as we are returning the
volume size, which in general will be greater than the actual snapshot
size.

Since the CSI spec allows us to return an undefined value we should do
so, since we can't tell the real size via cinderlib.

Fix: #60