### PR TITLE
Auto create directories and touch known hosts file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ ENV PYTHONUNBUFFERED=true
 # We need to upgrade pyasn1 because the package for RDO is not new enough for
 # pyasn1_modules, which is used by some of the Google's libraries
 RUN yum -y install xfsprogs e2fsprogs btrfs-progs nmap-ncat python2-future && \
-    mkdir -p /var/lib/ember-csi/{vols,locks} && \
-    touch /var/lib/ember-csi/ssh_known_hosts && \
     pip install --no-cache-dir --upgrade 'pyasn1<0.5.0,>=0.4.1' future && \
     yum clean all && \
     rm -rf /var/cache/yum

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -20,8 +20,6 @@ RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-
     # Apply cinderlib patch
     cd cinder && git fetch https://git.openstack.org/openstack/cinder refs/changes/69/620669/14 && git checkout FETCH_HEAD && cd .. && \
     pip install --no-cache-dir cinder/ && \
-    mkdir -p /var/lib/ember-csi/{vols,locks} && \
-    touch /var/lib/ember-csi/ssh_known_hosts && \
     rm -rf cinder && \
     yum -y remove git python-devel gcc && \
     yum clean all && \

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -10,8 +10,6 @@ ENV PYTHONUNBUFFERED=true
 # We need to upgrade pyasn1 because the package for RDO is not new enough for
 # pyasn1_modules, which is used by some of the Google's libraries
 RUN yum -y install xfsprogs e2fsprogs btrfs-progs python2-future && \
-    mkdir -p /var/lib/ember-csi/{vols,locks} && \
-    touch /var/lib/ember-csi/ssh_known_hosts && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     pip install --no-cache-dir --upgrade --process-dependency-links 'pyasn1<0.5.0,>=0.4.1' future ember-csi


### PR DESCRIPTION
To facilitate mounting directories on hosts in OC deployments we now
create locks and volume ding directories, and known hosts file on start
if they don't already exist.