### PR TITLE
Log pools on start

### DIFF
--- a/ember_csi/base.py
+++ b/ember_csi/base.py
@@ -239,6 +239,10 @@ class ControllerBase(IdentityBase):
         self.CTRL_CAPABILITIES_RESP = self.TYPES.CtrlCapabilityResp(
             capabilities=capab)
 
+        if len(self.backend.pool_names) > 1:
+            LOG.info('Available pools: %s' %
+                     ', '.join(self.backend.pool_names))
+
     def _get_size(self, what, request, default):
         vol_size = getattr(request.capacity_range, what + '_bytes', None)
         if vol_size:


### PR DESCRIPTION
Now that we can pass the pool_name as a parameter when creating volumes,
it would be convenient to see the pool names if we have more than one.