### PR TITLE
Fix #77: ValueError volume_content_source

### DIFF
--- a/ember_csi/v0_3_0/csi.py
+++ b/ember_csi/v0_3_0/csi.py
@@ -73,7 +73,7 @@ class Controller(base.TopologyBase, base.SnapshotBase, base.ControllerBase):
         # if not request.HasField('volume_content_source'):
         #    parameters['content_source'] = request.content_source
         if vol.snapshot_id:
-            parameters['volume_content_source'] = types.VolumeContentSource(
+            parameters['content_source'] = types.VolumeContentSource(
                 snapshot=types.SnapshotSource(snapshot_id=vol.snapshot_id))
 
         # accessible_topology should only be returned if we reported

--- a/ember_csi/v1_0_0/csi.py
+++ b/ember_csi/v1_0_0/csi.py
@@ -99,11 +99,11 @@ class Controller(base.TopologyBase, base.SnapshotBase, base.ControllerBase):
         # if not request.HasField('volume_content_source'):
         #    parameters['content_source'] = request.content_source
         if vol.source_volid:
-            parameters['volume_content_source'] = types.VolumeContentSource(
+            parameters['content_source'] = types.VolumeContentSource(
                 volume=types.VolumeSource(volume_id=vol.source_vol_id))
 
         elif vol.snapshot_id:
-            parameters['volume_content_source'] = types.VolumeContentSource(
+            parameters['content_source'] = types.VolumeContentSource(
                 snapshot=types.SnapshotSource(snapshot_id=vol.snapshot_id))
 
         # accessible_topology should only be returned if we reported


### PR DESCRIPTION
We could not create volumes from snapshots, as we would get the
following error on the CSI plugin:

ValueError: Protocol message Volume has no "volume_content_source"
field.

We were using "volume_content_source" instead of "content_source" when
returning the created volume information, fix it.