### PR TITLE
Fix #82: ListVolumes not working

### DIFF
--- a/ember_csi/base.py
+++ b/ember_csi/base.py
@@ -143,7 +143,7 @@ class IdentityBase(object):
 
     def _validate_name(self, name):
         if name and re.match(r'^[A-Za-z]{2,6}(\.[A-Za-z0-9-]{1,63})+$', name):
-                return name
+            return name
 
         return defaults.NAME
 
@@ -348,7 +348,8 @@ class ControllerBase(IdentityBase):
             context.abort(grpc.StatusCode.ABORTED,
                           'Operation pending for volume (%s)' % vol.status)
 
-        return self._convert_volume_type(vol)
+        volume = self._convert_volume_type(vol)
+        return self.TYPES.CreateResp(volume=volume)
 
     def _convert_volume_params(self, request, context):
         params = {'qos_specs': {}, 'extra_specs': {}}
@@ -486,7 +487,8 @@ class ControllerBase(IdentityBase):
         selected, token = self._paginate(request, context, vols)
 
         # TODO(geguileo): Once we support volume types set attributes
-        entries = [self._convert_volume_type(vol) for vol in selected]
+        entries = [self.TYPES.Entry(volume=self._convert_volume_type(vol))
+                   for vol in selected]
         fields = {'entries': entries}
         if token:
             fields['next_token'] = token

--- a/ember_csi/v0_2_0/csi.py
+++ b/ember_csi/v0_2_0/csi.py
@@ -38,10 +38,9 @@ class Controller(base.ControllerBase):
     # Requires _convert_volume_type method.
     def _convert_volume_type(self, vol):
         specs = vol.volume_type.extra_specs if vol.volume_type_id else None
-        volume = types.Volume(capacity_bytes=int(vol.size * constants.GB),
-                              id=vol.id,
-                              attributes=specs)
-        return types.CreateResp(volume=volume)
+        return types.Volume(capacity_bytes=int(vol.size * constants.GB),
+                            id=vol.id,
+                            attributes=specs)
 
     # DeleteVolume implemented on base Controller class
 

--- a/ember_csi/v0_3_0/csi.py
+++ b/ember_csi/v0_3_0/csi.py
@@ -81,8 +81,7 @@ class Controller(base.TopologyBase, base.SnapshotBase, base.ControllerBase):
         if self.TOPOLOGIES:
             parameters['accessible_topology'] = self.TOPOLOGIES
 
-        volume = types.Volume(**parameters)
-        return types.CreateResp(volume=volume)
+        return types.Volume(**parameters)
 
     # DeleteVolume implemented on base Controller class
 

--- a/ember_csi/v1_0_0/csi.py
+++ b/ember_csi/v1_0_0/csi.py
@@ -111,8 +111,7 @@ class Controller(base.TopologyBase, base.SnapshotBase, base.ControllerBase):
         if self.TOPOLOGIES:
             parameters['accessible_topology'] = self.TOPOLOGIES
 
-        volume = types.Volume(**parameters)
-        return types.CreateResp(volume=volume)
+        return types.Volume(**parameters)
 
     # DeleteVolume implemented on base Controller class
 


### PR DESCRIPTION
ListVolumes was broken because we were returning CreateResp instead of
Volume in the _convert_volume_type methods, and the ListVolume method
was not converting the Volume to an Entry.

This patch fixes these issues.