### PR TITLE
Add K8S v1.13 example with CSI v1

### DIFF
--- a/examples/k8s_v1.13-CSI_v1.0/README.md
+++ b/examples/k8s_v1.13-CSI_v1.0/README.md
@@ -1,0 +1,596 @@
+
+ADD
+
+ kubectl get csinodeinfo.csi.storage.k8s.io  --> Works
+
+
+Fails:
+kubectl get csidrivers.csi.storage.k8s.io
+
+
+# Kubernetes setup
+
+This demo deploys a Kubernetes single CentOS 7 master cluster, as the infra node, with 2 additional nodes, as workload nodes, using [kubeadm](http://kubernetes.io/docs/admin/kubeadm/) and Ember-CSI as the storage provider running v1.0 of the CSI spec with an LVM loopback device as the backend.
+
+CSI driver is set as the default storage class, running 1 service (`StatefulSet`) with the CSI plugin running as *Controller* to manage the provisioning on *master*, as part of the infrastructure, and a service (`DaemonSet`) running the plugin as *Node* mode on each of the nodes to manage local attachments.
+
+This example uses Vagrant, libvirt, KVM, and Ansible to create and provision these 3 VMs.
+
+**These Ansible playbooks are not idempotent, so don't run them more than once**
+
+This demo is based on Luis Pabon's [Kubeup repository](https://github.com/lpabon/kubeup).
+
+## Requirements
+
+Install qemu-kvm, libvirt, vagrant-libvirt, and ansible.
+
+* Fedora
+
+```
+$ sudo dnf -y install qemu-kvm libvirt vagrant-libvirt ansible
+```
+
+
+## Configuration
+
+Running the demo with the default LVM storage backend requires no configuration changes.
+
+If we want to use a different storage backend we need to edit the `kubeyml/controller.yml` file to change the storage configuration for the CSI plugin. This is done by changing the *value* of the `X_CSI_BACKEND_CONFIG` environmental variable with our own driver configuration.  For more information on the specific driver configuration please refer to the [cinderlib documentation](https://cinderlib.readthedocs.io), specifically to the [Backend section](https://cinderlib.readthedocs.io/en/latest/topics/backends.html), and the [Validated drivers' section](https://cinderlib.readthedocs.io/en/latest/validated_backends.html).
+
+The `Vagranfile` defines 2 nodes and a master, each with 4GB and 2 cores.  This can be changed using variables `NODES`, `MEMORY`, and `CPUS` in this file.
+
+
+## Setup
+
+The demo supports local and remote libvirt, for those that use an external box where they run their VMs.
+
+Local setup of the demo can be done running the `up.sh` script, be aware that this will take a while:
+
+```
+$ ./up.sh
+Bringing machine 'master' up with 'libvirt' provider...
+Bringing machine 'node0' up with 'libvirt' provider...
+Bringing machine 'node1' up with 'libvirt' provider...
+==> master: Checking if box 'centos/7' is up to date...
+==> node1: Checking if box 'centos/7' is up to date...
+==> node0: Checking if box 'centos/7' is up to date...
+
+[ . . . ]
+
+PLAY RECAP *********************************************************************
+master                     : ok=55   changed=44   unreachable=0    failed=0
+node0                      : ok=22   changed=20   unreachable=0    failed=0
+node1                      : ok=22   changed=20   unreachable=0    failed=0
+```
+
+Remote configuration requires defining our remote libvirt system using `LIBVIRT_HOST` and `LIBVIRT_USER` environmental variables before calling the `up.sh` script.
+
+`LIBVIRT_USER` defaults to `root`, so we don't need to set it up if that's what we want to use:
+
+```
+$ export LIBVIRT_HOST=192.168.1.11
+$ ./up.sh
+Bringing machine 'master' up with 'libvirt' provider...
+Bringing machine 'node0' up with 'libvirt' provider...
+Bringing machine 'node1' up with 'libvirt' provider...
+==> master: Checking if box 'centos/7' is up to date...
+==> node1: Checking if box 'centos/7' is up to date...
+==> node0: Checking if box 'centos/7' is up to date...
+
+[ . . . ]
+
+PLAY RECAP *********************************************************************
+master                     : ok=55   changed=44   unreachable=0    failed=0
+node0                      : ok=22   changed=20   unreachable=0    failed=0
+node1                      : ok=22   changed=20   unreachable=0    failed=0
+```
+
+
+## Development Setup
+
+If we are doing development, or if we want to test our own Ember-CSI images, for example if we have added a driver dependency, we can use our own registry.
+
+Here's an example of what we would do to test a 3PAR iSCSI backend, which has dependencies that are not currently included in any of the Ember-CSI images:
+
+First we would create our docker image, with a `Dockerfile` such as this:
+
+```
+FROM embercsi/ember-csi:master
+RUN pip install 'python-3parclient>=4.1.0'
+```
+
+Then we build and tag the image with our IP address:
+
+```
+# We need to know our IP address
+$ MY_IP=$(bash -c 'a="`hostname -I`"; s=($a); echo ${s[0]}')
+$ docker build -t $MY_IP/ember-csi:testing .
+```
+
+Now we run our own registry and publish our image:
+
+```
+$ docker run -d -p 5000:5000 --name registry registry:2
+$ docker push -t $MY_IP:5000/ember-csi:testing
+```
+
+Then, we edit file `roles/common/files/daemon.json` and replace the IP with our own, so that docker can pull images from our insecure registry, and change the images we want to use:
+
+```
+$ sed -i "s/192.168.1.11:5000/$MY_IP:5000/" roles/common/files/daemon.json
+$ sed -i "s/embercsi\/ember-csi:master/$MY_IP:5000\/ember-csi:testing/" kubeyml/node.yml
+$ sed -i "s/embercsi\/ember-csi:master/$MY_IP:5000\/ember-csi:testing/" kubeyml/controller.yml
+```
+
+With that, we are now ready to use our own custom image when deploying Ember-CSI in this example, but since we wanted to use the 3PAR backend we have to change the configuration editing `kubeyml/controller.yml` and changing the value of the environmental vairiable `X_CSI_BACKEND_CONFIG` with our backend's configuration.
+
+
+## Usage
+
+After the setup is completed the Kubernetes configuration is copied from the master node to the host, so we can use it locally as follows:
+
+```
+$ kubectl --kubeconfig=kubeconfig.conf get nodes
+master    Ready     master    21m       v1.13.2
+node0     Ready     <none>    21m       v1.13.2
+node1     Ready     <none>    21m       v1.13.2
+```
+
+Or we can just SSH into the master and run commands in there:
+```
+$ vagrant ssh master
+Last login: Tue Jul 24 10:12:40 2018 from 192.168.121.1
+[vagrant@master ~]$ kubectl get nodes
+NAME      STATUS    ROLES     AGE       VERSION
+master    Ready     master    21m       v1.13.2
+node0     Ready     <none>    21m       v1.13.2
+node1     Ready     <none>    21m       v1.13.2
+```
+
+Unless stated otherwise, all the following commands are run assuming we are in the *master* node.
+
+We can check that the CSI *controller* service is running in master:
+
+```
+[vagrant@master ~]$ kubectl get pod csi-controller-0
+NAME               READY     STATUS    RESTARTS   AGE
+csi-controller-0   5/5       Running   0          22m
+
+[vagrant@master ~]$ kubectl describe pod csi-controller-0 | grep Node:
+Node:               master/192.168.10.90
+```
+
+Check the logs of the CSI *controller* to see that its running as expected:
+
+```
+[vagrant@master ~]$ kubectl logs csi-controller-0 -c csi-driver
+2019-01-31 16:13:18 INFO ember_csi.ember_csi [-] Ember CSI v0.0.2 with 30 workers (cinder: v13.1.0.dev731, CSI spec: v1.0.0)
+2019-01-31 16:13:18 INFO ember_csi.ember_csi [-] Persistence module: CRDPersistence
+2019-01-31 16:13:18 INFO ember_csi.ember_csi [-] Running as controller with backend LVMVolumeDriver v3.0.0
+2019-01-31 16:13:18 INFO ember_csi.ember_csi [-] Debugging feature is ENABLED with ember_csi.rpdb and OFF. Toggle it with SIGUSR1.
+2019-01-31 16:13:18 INFO ember_csi.ember_csi [-] Supported filesystems: cramfs, minix, btrfs, ext2, ext3, ext4, xfs
+2019-01-31 16:13:18 INFO ember_csi.ember_csi [-] Now serving on unix:///csi-data/csi.sock...
+2019-01-31 16:13:18 INFO ember_csi.common [req-139778109350928] => GRPC Probe
+2019-01-31 16:13:18 INFO ember_csi.common [req-139778109350928] <= GRPC Probe served in 0s
+2019-01-31 16:13:18 INFO ember_csi.common [req-139778109350568] => GRPC GetPluginInfo
+2019-01-31 16:13:18 INFO ember_csi.common [req-139778109350568] <= GRPC GetPluginInfo served in 0s
+2019-01-31 16:13:18 INFO ember_csi.common [req-139778109351048] => GRPC GetPluginCapabilities
+2019-01-31 16:13:18 INFO ember_csi.common [req-139778109351048] <= GRPC GetPluginCapabilities served in 0s
+2019-01-31 16:13:18 INFO ember_csi.common [req-139778109350928] => GRPC ControllerGetCapabilities
+2019-01-31 16:13:18 INFO ember_csi.common [req-139778109350928] <= GRPC ControllerGetCapabilities served in 0s
+2019-01-31 16:13:19 INFO ember_csi.common [req-139778109350568] => GRPC GetPluginInfo
+2019-01-31 16:13:19 INFO ember_csi.common [req-139778109350568] <= GRPC GetPluginInfo served in 0s
+2019-01-31 16:13:19 INFO ember_csi.common [req-139778109351048] => GRPC Probe
+2019-01-31 16:13:19 INFO ember_csi.common [req-139778109351048] <= GRPC Probe served in 0s
+2019-01-31 16:13:19 INFO ember_csi.common [req-139778109350928] => GRPC ControllerGetCapabilities
+2019-01-31 16:13:19 INFO ember_csi.common [req-139778109350928] <= GRPC ControllerGetCapabilities served in 0s
+```
+
+Check that the CSI *node* services are also running:
+
+```
+[vagrant@master ~]$ kubectl get pod --selector=app=csi-node
+NAME             READY     STATUS    RESTARTS   AGE
+csi-node-29sls   3/3       Running   0          29m
+csi-node-p7r9r   3/3       Running   1          29m
+```
+
+We can also check all CSI drivers that have been registered in the system:
+
+```
+[vagrant@master ~]$ kubectl get csinodeinfo.csi.storage.k8s.io
+NAME    AGE
+node0   19m
+node1   19m
+
+[vagrant@master ~]$ kubectl describe csinodeinfo.csi.storage.k8s.io
+Name:         node0
+Namespace:
+Labels:       <none>
+Annotations:  <none>
+API Version:  csi.storage.k8s.io/v1alpha1
+Kind:         CSINodeInfo
+Metadata:
+  Creation Timestamp:  2019-01-31T16:16:33Z
+  Generation:          2
+  Owner References:
+    API Version:     v1
+    Kind:            Node
+    Name:            node0
+    UID:             782926e7-2572-11e9-ac8a-5254009990ac
+  Resource Version:  1327
+  Self Link:         /apis/csi.storage.k8s.io/v1alpha1/csinodeinfos/node0
+  UID:               9379f5cd-2573-11e9-9fee-5254009990ac
+Spec:
+  Drivers:
+    Name:     io.ember-csi
+    Node ID:  node0
+    Topology Keys:
+Status:
+  Drivers:
+    Available:                true
+    Name:                     io.ember-csi
+    Volume Plugin Mechanism:  in-tree
+Events:                       <none>
+
+
+Name:         node1
+Namespace:
+Labels:       <none>
+Annotations:  <none>
+API Version:  csi.storage.k8s.io/v1alpha1
+Kind:         CSINodeInfo
+Metadata:
+  Creation Timestamp:  2019-01-31T16:16:33Z
+  Generation:          2
+  Owner References:
+    API Version:     v1
+    Kind:            Node
+    Name:            node1
+    UID:             781c207f-2572-11e9-ac8a-5254009990ac
+  Resource Version:  1317
+  Self Link:         /apis/csi.storage.k8s.io/v1alpha1/csinodeinfos/node1
+  UID:               9354055e-2573-11e9-9fee-5254009990ac
+Spec:
+  Drivers:
+    Name:     io.ember-csi
+    Node ID:  node1
+    Topology Keys:
+Status:
+  Drivers:
+    Available:                true
+    Name:                     io.ember-csi
+    Volume Plugin Mechanism:  in-tree
+Events:                       <none>
+```
+
+Check the CSI *node* logs:
+
+```
+[vagrant@master ~]$ kubectl logs csi-node-29sls -c csi-driver
+2019-01-31 16:16:32 WARNING os_brick.initiator.connectors.nvme [-] Unable to locate dmidecode. For Cinder RSD Backend, please make sure it is installed: [Errno 2] No such file or directory
+Command: dmidecode
+Exit code: -
+Stdout: None
+Stderr: None: ProcessExecutionError: [Errno 2] No such file or directory
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Ember CSI v0.0.2 with 30 workers (cinder: v13.1.0.dev731, CSI spec: v1.0.0)
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Persistence module: CRDPersistence
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Running as node
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Debugging feature is ENABLED with ember_csi.rpdb and OFF. Toggle it with SIGUSR1.
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Supported filesystems: cramfs, minix, btrfs, ext2, ext3, ext4, xfs
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Now serving on unix:///csi-data/csi.sock...
+2019-01-31 16:16:33 INFO ember_csi.common [req-139891336430728] => GRPC GetPluginInfo
+2019-01-31 16:16:33 INFO ember_csi.common [req-139891336430728] <= GRPC GetPluginInfo served in 0s
+2019-01-31 16:16:33 INFO ember_csi.common [req-139891336430368] => GRPC NodeGetInfo
+2019-01-31 16:16:33 INFO ember_csi.common [req-139891336430368] <= GRPC NodeGetInfo served in 0s
+
+
+[vagrant@master ~]$ kubectl logs csi-node-p7r9r -c csi-driver
+2019-01-31 16:16:32 WARNING os_brick.initiator.connectors.nvme [-] Unable to locate dmidecode. For Cinder RSD Backend, please make sure it is installed: [Errno 2] No such file or directory
+Command: dmidecode
+Exit code: -
+Stdout: None
+Stderr: None: ProcessExecutionError: [Errno 2] No such file or directory
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Ember CSI v0.0.2 with 30 workers (cinder: v13.1.0.dev731, CSI spec: v1.0.0)
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Persistence module: CRDPersistence
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Running as node
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Debugging feature is ENABLED with ember_csi.rpdb and OFF. Toggle it with SIGUSR1.
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Supported filesystems: cramfs, minix, btrfs, ext2, ext3, ext4, xfs
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Now serving on unix:///csi-data/csi.sock...
+2019-01-31 16:16:33 INFO ember_csi.common [req-140339816875144] => GRPC GetPluginInfo
+2019-01-31 16:16:33 INFO ember_csi.common [req-140339816875144] <= GRPC GetPluginInfo served in 0s
+2019-01-31 16:16:33 INFO ember_csi.common [req-140339816874784] => GRPC NodeGetInfo
+2019-01-31 16:16:33 INFO ember_csi.common [req-140339816874784] <= GRPC NodeGetInfo served in 0s
+```
+
+
+Check the connection information that the *node* services are storing in Kubernetes to be used by the *controller* to export and map volumes to them:
+
+```
+[vagrant@master ~]$ kubectl get keyvalue
+NAME      AGE
+node0     30m
+node1     30m
+
+[vagrant@master ~]$ kubectl describe kv
+Name:         node0
+Namespace:    default
+Labels:       <none>
+Annotations:  value:
+                {"platform":"x86_64","host":"node0","do_local_attach":false,"ip":"192.168.10.100","os_type":"linux2","multipath":false,"initiator":"iqn.19...
+API Version:  ember-csi.io/v1
+Kind:         KeyValue
+Metadata:
+  Creation Timestamp:  2019-01-31T16:16:32Z
+  Generation:          1
+  Resource Version:    1306
+  Self Link:           /apis/ember-csi.io/v1/namespaces/default/keyvalues/node0
+  UID:                 92e46590-2573-11e9-9fee-5254009990ac
+Events:                <none>
+
+
+Name:         node1
+Namespace:    default
+Labels:       <none>
+Annotations:  value:
+                {"platform":"x86_64","host":"node1","do_local_attach":false,"ip":"192.168.10.101","os_type":"linux2","multipath":false,"initiator":"iqn.19...
+API Version:  ember-csi.io/v1
+Kind:         KeyValue
+Metadata:
+  Creation Timestamp:  2019-01-31T16:16:32Z
+  Generation:          1
+  Resource Version:    1308
+  Self Link:           /apis/ember-csi.io/v1/namespaces/default/keyvalues/node1
+  UID:                 92e6031f-2573-11e9-9fee-5254009990ac
+Events:                <none>
+```
+
+Create a 1GB volume using provided PVC manifest:
+
+```
+[vagrant@master ~]$ kubectl create -f kubeyml/pvc.yml
+persistentvolumeclaim/csi-pvc created
+```
+
+Check the PVC in Kubernetes, and its metadata from the CSI plugin stored in Kubernetes using CRDs:
+
+```
+$ kubectl get pvc
+[vagrant@master ~]$ kubectl get pvc
+NAME      STATUS    VOLUME                 CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+csi-pvc   Pending                                                    csi-sc         1s
+
+
+[vagrant@master ~]$ kubectl get pvc
+NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+csi-pvc   Bound    pvc-2a286b60-2574-11e9-9fee-5254009990ac   1Gi        RWO            csi-sc         11s
+
+
+[vagrant@master ~]$ kubectl get vol
+NAME                                   AGE
+82e9460c-cd04-4e08-94bb-7149b2805065   1m
+
+
+[vagrant@master ~]$ kubectl describe vol
+Name:         82e9460c-cd04-4e08-94bb-7149b2805065
+Namespace:    default
+Labels:       backend_name=lvm
+              volume_id=82e9460c-cd04-4e08-94bb-7149b2805065
+              volume_name=pvc-2a286b60-2574-11e9-9fee-5254009990ac
+Annotations:  json:
+                {"ovo":{"versioned_object.version":"1.8","versioned_object.name":"Volume","versioned_object.data":{"migration_status":null,"provider_id":n...
+API Version:  ember-csi.io/v1
+Kind:         Volume
+Metadata:
+  Creation Timestamp:  2019-01-31T16:20:46Z
+  Generation:          1
+  Resource Version:    1690
+  Self Link:           /apis/ember-csi.io/v1/namespaces/default/volumes/82e9460c-cd04-4e08-94bb-7149b2805065
+  UID:                 2a6d8a7c-2574-11e9-9fee-5254009990ac
+Events:                <none>
+```
+
+Each one of the CSI plugin services is running the `embercsi/csc` container, allowing us to easily send commands directly to CSI plugins using the [Container Storage Client](https://github.com/rexray/gocsi/tree/master/csc).
+
+For example, we can request the CSI *controller* plugin to list volumes with:
+
+```
+[vagrant@master ~]$ kubectl exec -c csc csi-controller-0 csc controller list-volumes
+"82e9460c-cd04-4e08-94bb-7149b2805065"  1073741824
+```
+
+Now we are going to create a container on *node1*, where neither the CSI *controller* nor the LVM reside, using the `app.yml` manifest that mounts the EXT4 PVC we just created into the `/data` directory:
+
+```
+[vagrant@master ~]$ kubectl create -f kubeyml/app.yml
+pod/my-csi-app created
+
+```
+
+Tail the CSI *controller* plugin logs to see that the plugin exports the volume:
+
+```
+[vagrant@master ~]$ kubectl logs csi-controller-0 -fc csi-driver
+2019-01-31 16:13:18 INFO ember_csi.ember_csi [-] Ember CSI v0.0.2 with 30 workers (cinder: v13.1.0.dev731, CSI spec: v1.0.0)
+
+[ . . .]
+
+2019-01-31 16:20:46 INFO ember_csi.common [req-139778109350568] => GRPC GetPluginCapabilities
+2019-01-31 16:20:46 INFO ember_csi.common [req-139778109350568] <= GRPC GetPluginCapabilities served in 0s
+2019-01-31 16:20:46 INFO ember_csi.common [req-139778109351048] => GRPC ControllerGetCapabilities
+2019-01-31 16:20:46 INFO ember_csi.common [req-139778109351048] <= GRPC ControllerGetCapabilities served in 0s
+2019-01-31 16:20:46 INFO ember_csi.common [req-139778109350928] => GRPC GetPluginInfo
+2019-01-31 16:20:46 INFO ember_csi.common [req-139778109350928] <= GRPC GetPluginInfo served in 0s
+2019-01-31 16:20:46 INFO ember_csi.common [req-139778109350568] => GRPC CreateVolume pvc-2a286b60-2574-11e9-9fee-5254009990ac
+2019-01-31 16:20:46 INFO ember_csi.common [req-139778109350568] <= GRPC CreateVolume (id = 82e9460c-cd04-4e08-94bb-7149b2805065) served in 0s
+2019-01-31 16:22:56 INFO ember_csi.common [req-139778109353208] => GRPC ListVolumes
+2019-01-31 16:22:56 INFO ember_csi.common [req-139778109353208] <= GRPC ListVolumes served in 0s
+2019-01-31 16:23:32 INFO ember_csi.common [req-139778109350928] => GRPC ControllerPublishVolume 82e9460c-cd04-4e08-94bb-7149b2805065
+2019-01-31 16:23:34 INFO ember_csi.common [req-139778109350928] <= GRPC ControllerPublishVolume served in 2s
+2019-01-31 16:23:34 INFO ember_csi.common [req-139778109353328] => GRPC ControllerPublishVolume 82e9460c-cd04-4e08-94bb-7149b2805065
+2019-01-31 16:23:34 INFO ember_csi.common [req-139778109353328] <= GRPC ControllerPublishVolume served in 0s
+^C
+```
+
+Tail the CSI *node* plugin logs to see that the plugin actually attaches the volume to the container:
+
+```
+2019-01-31 16:16:32 INFO ember_csi.ember_csi [-] Ember CSI v0.0.2 with 30 workers (cinder: v13.1.0.dev731, CSI spec: v1.0.0)
+
+[ . . . ]
+
+2019-01-31 16:23:40 INFO ember_csi.common [req-139891336430248] => GRPC NodeGetCapabilities
+2019-01-31 16:23:40 INFO ember_csi.common [req-139891336430248] <= GRPC NodeGetCapabilities served in 0s
+2019-01-31 16:23:40 INFO ember_csi.common [req-139891336430008] => GRPC NodeStageVolume 82e9460c-cd04-4e08-94bb-7149b2805065
+2019-01-31 16:23:42 WARNING os_brick.initiator.connectors.iscsi [req-139891336430008] iscsiadm stderr output when getting sessions: iscsiadm: No active sessions.
+
+2019-01-31 16:23:45 INFO ember_csi.common [req-139891336430008] <= GRPC NodeStageVolume served in 5s
+2019-01-31 16:23:45 INFO ember_csi.common [req-139891336430128] => GRPC NodeGetCapabilities
+2019-01-31 16:23:45 INFO ember_csi.common [req-139891336430128] <= GRPC NodeGetCapabilities served in 0s
+2019-01-31 16:23:45 INFO ember_csi.common [req-139891336430248] => GRPC NodePublishVolume 82e9460c-cd04-4e08-94bb-7149b2805065
+2019-01-31 16:23:45 INFO ember_csi.common [req-139891336430248] <= GRPC NodePublishVolume served in 0s
+
+^C
+```
+
+Check that the pod has been successfully created:
+
+```
+[vagrant@master ~]$ kubectl get pod my-csi-app
+NAME         READY     STATUS    RESTARTS   AGE
+my-csi-app   1/1       Running   0          7m
+```
+
+We can check the connection information the CSI plugins store on Kubernetes:
+
+```
+[vagrant@master ~]$ kubectl get conn
+NAME                                   AGE
+91c4efb1-e656-462a-9e57-721f73febdb9   7m
+
+
+[vagrant@master ~]$ kubectl describe conn
+Name:         91c4efb1-e656-462a-9e57-721f73febdb9
+Namespace:    default
+Labels:       connection_id=91c4efb1-e656-462a-9e57-721f73febdb9
+              volume_id=82e9460c-cd04-4e08-94bb-7149b2805065
+Annotations:  json:
+                {"ovo":{"versioned_object.version":"1.3","versioned_object.name":"VolumeAttachment","versioned_object.data":{"instance_uuid":null,"detach_...
+API Version:  ember-csi.io/v1
+Kind:         Connection
+Metadata:
+  Creation Timestamp:  2019-01-31T16:23:34Z
+  Generation:          1
+  Resource Version:    1957
+  Self Link:           /apis/ember-csi.io/v1/namespaces/default/connections/91c4efb1-e656-462a-9e57-721f73febdb9
+  UID:                 8e79ca7f-2574-11e9-9fee-5254009990ac
+Events:                <none>
+```
+
+Get all the Ember-CSI related metadata:
+
+```
+[vagrant@master ~]$ kubectl get ember
+NAME                                                           AGE
+connection.ember-csi.io/91c4efb1-e656-462a-9e57-721f73febdb9   3m
+
+NAME                          AGE
+keyvalue.ember-csi.io/node0   10m
+keyvalue.ember-csi.io/node1   10m
+
+NAME                                                       AGE
+volume.ember-csi.io/82e9460c-cd04-4e08-94bb-7149b2805065   6m
+```
+
+Now let's create a snapshot of our volume, and see its kubernetes and ember representations:
+
+```
+[vagrant@master ~]$ kubectl create -f kubeyml/snapshot.yml
+volumesnapshot.snapshot.storage.k8s.io/csi-snap created
+
+[vagrant@master ~]$ kubectl describe VolumeSnapshot
+Name:         csi-snap
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+API Version:  snapshot.storage.k8s.io/v1alpha1
+Kind:         VolumeSnapshot
+Metadata:
+  Creation Timestamp:  2019-01-31T16:28:46Z
+  Finalizers:
+    snapshot.storage.kubernetes.io/volumesnapshot-protection
+  Generation:        5
+  Resource Version:  2396
+  Self Link:         /apis/snapshot.storage.k8s.io/v1alpha1/namespaces/default/volumesnapshots/csi-snap
+  UID:               48877e0d-2575-11e9-9fee-5254009990ac
+Spec:
+  Snapshot Class Name:    csi-snap
+  Snapshot Content Name:  snapcontent-48877e0d-2575-11e9-9fee-5254009990ac
+  Source:
+    API Group:  <nil>
+    Kind:       PersistentVolumeClaim
+    Name:       csi-pvc
+Status:
+  Creation Time:  2019-01-31T16:28:47Z
+  Ready To Use:   true
+  Restore Size:   <nil>
+Events:           <none>
+
+[vagrant@master ~]$ kubectl describe snap
+Name:         e37b0fd0-b7f1-4e9d-b455-a968b5a02964
+Namespace:    default
+Labels:       snapshot_id=e37b0fd0-b7f1-4e9d-b455-a968b5a02964
+              snapshot_name=snapshot-48877e0d-2575-11e9-9fee-5254009990ac
+              volume_id=82e9460c-cd04-4e08-94bb-7149b2805065
+Annotations:  json:
+                {"ovo":{"versioned_object.version":"1.5","versioned_object.name":"Snapshot","versioned_object.data":{"provider_id":null,"updated_at":null,...
+API Version:  ember-csi.io/v1
+Kind:         Snapshot
+Metadata:
+  Creation Timestamp:  2019-01-31T16:28:47Z
+  Generation:          1
+  Resource Version:    2391
+  Self Link:           /apis/ember-csi.io/v1/namespaces/default/snapshots/e37b0fd0-b7f1-4e9d-b455-a968b5a02964
+  UID:                 48de9c16-2575-11e9-9fee-5254009990ac
+Events:                <none>
+```
+
+Now create a volume from that snapshot:
+
+```
+[vagrant@master ~]$ kubectl create -f kubeyml/restore-snapshot.yml
+persistentvolumeclaim/vol-from-snap created
+
+[vagrant@master ~]$ kubectl get vol
+NAME                                   AGE
+0766345b-dc28-427e-9cba-d21654dd97cb   10s
+82e9460c-cd04-4e08-94bb-7149b2805065   11m
+```
+
+And create another container using this new volume.
+
+```
+[vagrant@master ~]$ kubectl create -f kubeyml/app-from-snap-vol.yml
+pod/my-csi-app-2 created
+
+[vagrant@master ~]$ kubectl get conn
+NAME                                   AGE
+4255bc1c-b8a6-40c1-8e11-f3218379cb2e   13s
+91c4efb1-e656-462a-9e57-721f73febdb9   9m
+
+[vagrant@master ~]$ kubectl get pod
+NAME               READY   STATUS    RESTARTS   AGE
+csi-controller-0   5/5     Running   0          21m
+csi-node-29sls     3/3     Running   0          18m
+csi-node-p7r9r     3/3     Running   1          18m
+my-csi-app         1/1     Running   0          10m
+my-csi-app-2       1/1     Running   0          38s
+```
+
+
+Remember that, for debuggin purposes, besides the logs, you can also get a Python console on GRPC requests by starting the debug mode, then executing bash into the node, installing `nmap-ncat`, and when a request is made connecting to port 4444.  For example, to toggle debug mode on the controller node:
+
+
+```
+$ kubectl exec csi-controller-0 -c csi-driver -- kill -USR1 1
+```

--- a/examples/k8s_v1.13-CSI_v1.0/Vagrantfile
+++ b/examples/k8s_v1.13-CSI_v1.0/Vagrantfile
@@ -1,0 +1,61 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+NODES = 2
+MEMORY = 4096
+CPUS = 2
+
+Vagrant.configure("2") do |config|
+    config.ssh.insert_key = false
+    config.vm.box = "centos/7"
+
+    # Override
+    config.vm.provider :libvirt do |v,override|
+        override.vm.synced_folder '.', '/home/vagrant/sync', disabled: true
+        v.memory = MEMORY
+        v.cpus = CPUS
+        v.nested = true
+        # Support remote libvirt
+        $libvirt_host = ENV.fetch('LIBVIRT_HOST', '')
+        $libvirt_user = ENV.fetch('LIBVIRT_USER', 'root')
+        v.host = $libvirt_host
+        if $libvirt_host.empty? || $libvirt_host.nil?
+            v.connect_via_ssh = false
+        else
+            v.username = $libvirt_user
+            v.connect_via_ssh = true
+        end
+    end
+
+    # Make kub master
+    config.vm.define :master do |master|
+        master.vm.network :private_network, ip: "192.168.10.90"
+        master.vm.host_name = "master"
+
+        # View the documentation for the provider you're using for more
+        # information on available options.
+        master.vm.provision :ansible do |ansible|
+            ansible.limit = "all"
+            ansible.playbook = "site.yml"
+            ansible.groups = {
+                "master_node" => ["master"],
+                "nodes" => (0..NODES-1).map {|j| "node#{j}"},
+            }
+            # Workaround for issue #644 on Vagrant < v1.8.6
+            # Replace the ProxyCommand with the command specified by
+            # vagrant ssh-config
+            req = Gem::Requirement.new('<1.8.6')
+            if req.satisfied_by?(Gem::Version.new(Vagrant::VERSION)) and not $libvirt_host.empty?
+                ansible.raw_ssh_args = "-o 'ProxyCommand=ssh #{$libvirt_host} -l #{$libvirt_user} -i #{Dir.home}/.ssh/id_rsa nc %h %p'"
+            end
+        end
+    end
+
+    # Define the nodes' names and networks
+    (0..NODES-1).each do |i|
+        config.vm.define "node#{i}" do |node|
+            node.vm.hostname = "node#{i}"
+            node.vm.network :private_network, ip: "192.168.10.10#{i}"
+        end
+    end
+end

--- a/examples/k8s_v1.13-CSI_v1.0/down.sh
+++ b/examples/k8s_v1.13-CSI_v1.0/down.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+lhost=${LIBVIRT_HOST:-''}
+luser=${LIBVIRT_USER:-'root'}
+
+LIBVIRT_HOST=$lhost LIBVIRT_USER=$luser vagrant destroy -f

--- a/examples/k8s_v1.13-CSI_v1.0/global_vars.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/global_vars.yml
@@ -1,0 +1,2 @@
+---
+kubernetes_token: abcdef.1234567890abcdef

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/app-from-snap-vol.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/app-from-snap-vol.yml
@@ -1,0 +1,19 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-csi-app-2
+spec:
+  containers:
+    - name: my-frontend
+      image: busybox
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: [ "sleep", "1000000" ]
+  # Pin the controller to node1, where there's no controller
+  nodeSelector:
+    kubernetes.io/hostname: node1
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: vol-from-snap # defined in restore-snapshot.yml

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/app.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/app.yml
@@ -1,0 +1,19 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-csi-app
+spec:
+  containers:
+    - name: my-frontend
+      image: busybox
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: [ "sleep", "1000000" ]
+  # Pin the controller to node1, where there's no controller
+  nodeSelector:
+    kubernetes.io/hostname: node1
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: csi-pvc # defined in pvc.yml

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/controller.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/controller.yml
@@ -1,0 +1,220 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-controller-sa
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-controller-cr
+rules:
+  # Allow managing ember resources
+  - apiGroups: ['ember-csi.io']
+    resources: ['*']
+    verbs: ['*']
+  # Allow listing and creating CRDs
+  - apiGroups: ['apiextensions.k8s.io']
+    resources: ['customresourcedefinitions']
+    verbs: ['list', 'create']
+  - apiGroups: ['']
+    resources: ['persistentvolumes']
+    verbs: ['create', 'delete', 'get', 'list', 'watch', 'update']
+  - apiGroups: ['']
+    resources: ['secrets']
+    verbs: ['get', 'list']
+  - apiGroups: ['']
+    resources: ['persistentvolumeclaims']
+    verbs: ['get', 'list', 'watch', 'update']
+  - apiGroups: ['']
+    resources: ['nodes']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['storage.k8s.io']
+    resources: ['volumeattachments']
+    verbs: ['get', 'list', 'watch', 'update']
+  - apiGroups: ['storage.k8s.io']
+    resources: ['storageclasses']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['']
+    resources: ['events']
+    verbs: ['list', 'watch', 'create', 'update', 'patch']
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-controller-rb
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: csi-controller-cr
+subjects:
+- kind: ServiceAccount
+  name: csi-controller-sa
+  namespace: default
+---
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: csi-controller
+spec:
+  serviceName: csi-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: csi-controller
+    spec:
+      serviceAccount: csi-controller-sa
+      # iSCSI only the very latest Open-iSCSI supports namespaces
+      hostNetwork: true
+      # Required by multipath detach (some drivers clone volumes dd-ing)
+      hostIPC: true
+      # Allow running it in master even if it's tainted for NoSchedule
+      tolerations:
+      - operator: "Exists"
+        key: "node-role.kubernetes.io/master"
+        effect: "NoSchedule"
+      # Pin the controller to node0, where we created the LVM backend
+      nodeSelector:
+        kubernetes.io/hostname: master
+      containers:
+      - name: external-provisioner
+        image: quay.io/k8scsi/csi-provisioner:v1.0.1
+        args:
+        - --v=5
+        - --provisioner=io.ember-csi
+        - --csi-address=/csi-data/csi.sock
+        volumeMounts:
+        - mountPath: /csi-data
+          name: socket-dir
+      - name: external-attacher
+        image: quay.io/k8scsi/csi-attacher:v1.0.1
+        args:
+        - --v=5
+        - --csi-address=/csi-data/csi.sock
+        - --timeout=120s
+        volumeMounts:
+        - mountPath: /csi-data
+          name: socket-dir
+      - name: external-snapshotter
+        image: quay.io/k8scsi/csi-snapshotter:v1.0.1
+        args:
+        - --v=5
+        - --csi-address=/csi-data/csi.sock
+        volumeMounts:
+        - mountPath: /csi-data
+          name: socket-dir
+      - name: csi-driver
+        image: embercsi/ember-csi:master
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+          allowPrivilegeEscalation: true
+        env:
+        - name: PYTHONUNBUFFERED
+          value: '0'
+        - name: CSI_ENDPOINT
+          value: unix:///csi-data/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: X_CSI_SPEC_VERSION
+          value: v1.0
+        - name: CSI_MODE
+          value: controller
+        - name: X_CSI_PERSISTENCE_CONFIG
+          value: '{"storage":"crd"}'
+        - name: X_CSI_BACKEND_CONFIG
+          value: '{"target_protocol":"iscsi","iscsi_ip_address":"192.168.10.100","name":"lvm","driver":"LVMVolume","volume_group":"ember-volumes","target_helper":"lioadm","multipath":false}'
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /csi-data
+        - name: iscsi-dir
+          mountPath: /etc/iscsi
+          mountPropagation: Bidirectional
+        - name: dev-dir
+          mountPath: /dev
+          mountPropagation: Bidirectional
+        - name: lvm-dir
+          mountPath: /etc/lvm
+          mountPropagation: Bidirectional
+        - name: lvm-lock
+          mountPath: /var/lock/lvm
+          mountPropagation: Bidirectional
+        - name: multipath-dir
+          mountPath: /etc/multipath
+          mountPropagation: Bidirectional
+        - name: multipath-conf
+          mountPath: /etc/multipath.conf
+          mountPropagation: HostToContainer
+        - name: modules-dir
+          mountPath: /lib/modules
+          mountPropagation: HostToContainer
+        - name: localtime
+          mountPath: /etc/localtime
+          mountPropagation: HostToContainer
+        - name: udev-data
+          mountPath: /run/udev
+          mountPropagation: HostToContainer
+        # Required to preserve the node targets between restarts
+        - name: iscsi-info
+          mountPath: /var/lib/iscsi
+          mountPropagation: Bidirectional
+        # In a real deployment we should be mounting container's
+        # /var/lib-ember-csi on the host
+      - name: csc
+        image: embercsi/csc:v1.0.0
+        command: ["tail"]
+        args: ["-f", "/dev/null"]
+        env:
+          - name: CSI_ENDPOINT
+            value: unix:///csi-data/csi.sock
+        volumeMounts:
+          - name: socket-dir
+            mountPath: /csi-data
+      volumes:
+      - name: socket-dir
+        emptyDir:
+      # Some backends do create volume from snapshot by attaching and dd-ing
+      - name: iscsi-dir
+        hostPath:
+          path: /etc/iscsi
+          type: Directory
+      - name: dev-dir
+        hostPath:
+          path: /dev
+      - name: lvm-dir
+        hostPath:
+          path: /etc/lvm
+          type: Directory
+      - name: lvm-lock
+        hostPath:
+          path: /var/lock/lvm
+      - name: multipath-dir
+        hostPath:
+          path: /etc/multipath
+      - name: multipath-conf
+        hostPath:
+          path: /etc/multipath.conf
+      - name: modules-dir
+        hostPath:
+          path: /lib/modules
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      - name: udev-data
+        hostPath:
+          path: /run/udev
+      - name: iscsi-info
+        hostPath:
+          path: /var/lib/iscsi

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/node.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/node.yml
@@ -1,0 +1,192 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-node-sa
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-node-cr
+rules:
+  # Allow managing ember resources
+  - apiGroups: ['ember-csi.io']
+    resources: ['*']
+    verbs: ['*']
+  # Allow listing and creating CRDs
+  - apiGroups: ['apiextensions.k8s.io']
+    resources: ['customresourcedefinitions']
+    verbs: ['list', 'create']
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-node-rb
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: csi-node-cr
+subjects:
+- kind: ServiceAccount
+  name: csi-node-sa
+  namespace: default
+---
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: csi-node
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: csi-node
+  template:
+    metadata:
+      labels:
+        app: csi-node
+    spec:
+      serviceAccount: csi-node-sa
+      # Required by iSCSI
+      hostNetwork: true
+      # Required by multipath detach
+      hostIPC: true
+      containers:
+        - name: driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+          args:
+          - --v=5
+          - --csi-address=/csi-data/csi.sock
+          - --kubelet-registration-path=/var/lib/kubelet/plugins/io.ember-csi/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /csi-data
+              name: socket-dir
+            - name: registration-dir
+              mountPath: /registration
+        - name: csi-driver
+          image: embercsi/ember-csi:master
+          securityContext:
+            privileged: true
+            allowPrivilegeEscalation: true
+          imagePullPolicy: Always
+          env:
+            - name: PYTHONUNBUFFERED
+              value: '0'
+            - name: X_CSI_SPEC_VERSION
+              value: v1.0
+            - name: CSI_ENDPOINT
+              value: unix:///csi-data/csi.sock
+            - name: CSI_MODE
+              value: node
+            - name: X_CSI_PERSISTENCE_CONFIG
+              value: '{"storage":"crd"}'
+            - name: X_CSI_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi-data
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: Bidirectional
+            - name: iscsi-dir
+              mountPath: /etc/iscsi
+              mountPropagation: Bidirectional
+            - name: dev-dir
+              mountPath: /dev
+              mountPropagation: Bidirectional
+            - name: lvm-conf
+              mountPath: /etc/lvm/lvm.conf
+              mountPropagation: HostToContainer
+            - name: lvm-lock
+              mountPath: /var/lock/lvm
+              mountPropagation: Bidirectional
+            - name: multipath-dir
+              mountPath: /etc/multipath
+              mountPropagation: Bidirectional
+            - name: multipath-conf
+              mountPath: /etc/multipath.conf
+              mountPropagation: HostToContainer
+            - name: modules-dir
+              mountPath: /lib/modules
+              mountPropagation: HostToContainer
+            - name: localtime
+              mountPath: /etc/localtime
+              mountPropagation: HostToContainer
+            - name: udev-data
+              mountPath: /run/udev
+              mountPropagation: HostToContainer
+            # Required to preserve the node targets between restarts
+            - name: iscsi-info
+              mountPath: /var/lib/iscsi
+              mountPropagation: Bidirectional
+            # In a real deployment we should be mounting container's
+            # /var/lib-ember-csi on the host
+        - name: csc
+          image: embercsi/csc:v1.0.0
+          command: ["tail"]
+          args: ["-f", "/dev/null"]
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi-data/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi-data
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/io.ember-csi
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: iscsi-dir
+          hostPath:
+            path: /etc/iscsi
+            type: Directory
+        - name: dev-dir
+          hostPath:
+            path: /dev
+        - name: lvm-conf
+          hostPath:
+            path: /etc/lvm/lvm.conf
+        - name: lvm-lock
+          hostPath:
+            path: /var/lock/lvm
+        - name: multipath-dir
+          hostPath:
+            path: /etc/multipath
+        - name: multipath-conf
+          hostPath:
+            path: /etc/multipath.conf
+        - name: modules-dir
+          hostPath:
+            path: /lib/modules
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - name: udev-data
+          hostPath:
+            path: /run/udev
+        - name: iscsi-info
+          hostPath:
+            path: /var/lib/iscsi

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/pvc.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/pvc.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: csi-sc

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/restore-snapshot.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/restore-snapshot.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vol-from-snap
+spec:
+  storageClassName: csi-sc
+  dataSource:
+    name: csi-snap
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/snapshot-class.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/snapshot-class.yml
@@ -1,0 +1,5 @@
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-snap
+snapshotter: io.ember-csi

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/snapshot.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/snapshot.yml
@@ -1,0 +1,9 @@
+apiVersion: snapshot.storage.k8s.io/v1alpha1
+kind: VolumeSnapshot
+metadata:
+  name: csi-snap
+spec:
+  snapshotClassName: csi-snap
+  source:
+    name: csi-pvc
+    kind: PersistentVolumeClaim

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/storage-class.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/storage-class.yml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-sc
+  namespace: default
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: io.ember-csi
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+## We can provide parameters to the driver if it supports them
+# parameters:
+## For example for drivers supporting pools, when we have multiple pools
+#  pool_name: rhos_cinder
+## QoS parameters must have the qos_ prefix
+#  qos_maxIOPS: "1000"
+## Extra specs must have the xtra_ prefix
+#  xtra_hpe3par:compression: "true"

--- a/examples/k8s_v1.13-CSI_v1.0/roles/common/files/daemon.json
+++ b/examples/k8s_v1.13-CSI_v1.0/roles/common/files/daemon.json
@@ -1,0 +1,1 @@
+{ "insecure-registries":["192.168.1.11:5000"] }

--- a/examples/k8s_v1.13-CSI_v1.0/roles/common/files/k8s.conf
+++ b/examples/k8s_v1.13-CSI_v1.0/roles/common/files/k8s.conf
@@ -1,0 +1,2 @@
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1

--- a/examples/k8s_v1.13-CSI_v1.0/roles/common/tasks/main.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/roles/common/tasks/main.yml
@@ -1,0 +1,109 @@
+- name: update
+  yum:
+    name: '*'
+    state: latest
+
+- name: build hosts file
+  lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_eth1.ipv4.address }} {{item}}" state=present
+  when: hostvars[item].ansible_eth1.ipv4.address is defined
+  with_items: "{{ groups['all'] }}"
+
+- name: disable selinux
+  selinux: state=disabled
+
+- name: disable of selinux - now
+  command: setenforce 0
+
+- name: Ensure net.bridge.bridge-nf-call-iptables is set. See kubeadm
+  copy: src=k8s.conf owner=root group=root dest=/etc/sysctl.d/k8s.conf
+
+- name: Run sysctl
+  command: sysctl --system
+
+- name: Add Kubernetes yum repo
+  yum_repository:
+    name: kubernetes
+    description: Kubernetes kubeadm
+    baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+    gpgkey: https://packages.cloud.google.com/yum/doc/yum-key.gpg
+    gpgcheck: yes
+
+# Pin kubernetes related packages to ensure we don't break every other day
+- name: install utility programs
+  yum: name={{ item }} state=present disable_gpg_check=yes
+  with_items:
+    - wget
+    - ntp
+    - screen
+    - epel-release
+    - vim
+    - iptables
+    - iptables-utils
+    - iptables-services
+    - ncurses-term
+    - docker
+    - kubelet-1.13.2
+    - kubeadm-1.13.2
+    - kubectl-1.13.2
+
+# Workaround for bugs:
+#  - https://github.com/kubernetes/kubernetes/issues/56850
+#  - https://github.com/kubernetes/kubernetes/issues/63804
+# Once we suport CSDriver extra info we should add ,CSIDriverRegistry=true to
+# the feature-gates
+- lineinfile:
+    path: /etc/sysconfig/kubelet
+    regexp: '^KUBELET_EXTRA_ARGS='
+    line: 'KUBELET_EXTRA_ARGS=--runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --feature-gates=CSIBlockVolume=true,VolumeSnapshotDataSource=true,CSINodeInfo=true'
+
+# Note(geguileo): If we want to use our own registry for developtment we just
+# need to edit the roles/common/files/daemon.json with the IP of our registry.
+# We can easily run a registry with:
+#     docker run -d -p 5000:5000 --name registry registry:2
+- name: Allow connecting to our own insecure registry
+  copy: src=daemon.json owner=root group=root dest=/etc/docker/daemon.json
+
+- name: enable kube services
+  service: name={{ item }} state=started enabled=yes
+  with_items:
+    - docker
+    - ntpd
+    - kubelet
+
+- name: turn off swap
+  command: swapoff -a
+
+- name: remove swap from /etc/fstab
+  lineinfile:
+    path: /etc/fstab
+    state: absent
+    regexp: "swap"
+
+- name: iptables open ports
+  command: iptables -A INPUT -p tcp -m state --state NEW -m multiport --dports 9000:9200 -j ACCEPT
+
+- name: save iptables
+  command: service iptables save
+
+# Accept loop devices for the LVM ember-volumes VG and reject anything else
+- name: Disable new LVM volumes
+  lineinfile:
+    path: /etc/lvm/lvm.conf
+    state: present
+    insertafter: '# filter ='
+    line: "\tfilter = [ \"a|loop|\", \"r|.*\\/|\" ]\n\tglobal_filter = [ \"a|loop|\", \"r|.*\\/|\" ]"
+
+- name: Install iSCSI
+  yum: name={{ item }} state=present
+  with_items:
+    - iscsi-initiator-utils
+    - device-mapper-multipath
+
+- name: Configure multipath
+  command: mpathconf --enable --with_multipathd y --user_friendly_names n --find_multipaths y
+
+- name: Enable connection services
+  service: name={{ item }} state=restarted enabled=yes
+  with_items:
+    - iscsid
+    - multipathd

--- a/examples/k8s_v1.13-CSI_v1.0/roles/master/tasks/main.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/roles/master/tasks/main.yml
@@ -1,0 +1,32 @@
+# Pin kubernetes version to ensure we don't break every other day
+# Disabling CoreDNS to workaround https://github.com/kubernetes/kubeadm/issues/998
+- name: initialize kubeadm on master
+  command: kubeadm init --pod-network-cidr=10.244.0.0/16 --token={{ kubernetes_token }} --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
+
+- name: create flannel network
+  shell: kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/v0.11.0/Documentation/kube-flannel.yml
+
+- name: get kubeconfig.conf
+  fetch:
+    src: /etc/kubernetes/admin.conf
+    dest: kubeconfig.conf
+    flat: yes
+
+- file: path=/home/vagrant/.kube state=directory group=vagrant owner=vagrant
+- name: Set default vagrant kubeconf
+  copy:
+    remote_src: True
+    src: /etc/kubernetes/admin.conf
+    dest: /home/vagrant/.kube/config
+    group: vagrant
+    owner: vagrant
+
+- file: path=/root/.kube state=directory
+- name: Set default root kubeconf
+  copy:
+    remote_src: True
+    src: /etc/kubernetes/admin.conf
+    dest: /root/.kube/config
+
+- import_tasks: setup_lvm.yml
+  become: yes

--- a/examples/k8s_v1.13-CSI_v1.0/roles/master/tasks/setup_lvm.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/roles/master/tasks/setup_lvm.yml
@@ -1,0 +1,42 @@
+- name: Create LVM backing file
+  command: truncate -s 10G /root/ember-volumes
+  args:
+      creates: ember-volumes
+
+- shell: "losetup -l | awk '/ember-volumes/ {print $1}'"
+  changed_when: false
+  register: existing_loop_device
+
+- name: Create loopback device
+  command: "losetup --show -f /root/ember-volumes"
+  register: new_loop_device
+  when: existing_loop_device.stdout == ''
+ # Workaround because Ansible destroys registers when skipped
+- set_fact: loop_device="{{ new_loop_device.stdout if new_loop_device.changed else existing_loop_device.stdout }}"
+
+- name: "Create PV"
+  shell: "pvcreate {{loop_device}} && touch /root/lvm.pvcreate"
+  args:
+      creates: /root/lvm.pvcreate
+
+- name: "Create VG"
+  shell: "vgcreate ember-volumes {{loop_device}} && touch /root/lvm.vgcreate"
+  args:
+      creates: /root/lvm.vgcreate
+
+- command: "vgscan --cache"
+  changed_when: false
+
+# Workaround for lvcreate hanging inside contatiner
+# https://serverfault.com/questions/802766/calling-lvcreate-from-inside-the-container-hangs
+- lineinfile:
+    path: /etc/lvm/lvm.conf
+    state: present
+    regexp: "^\tudev_sync = 1"
+    line: "\tudev_sync = 0"
+
+- lineinfile:
+    path: /etc/lvm/lvm.conf
+    state: present
+    regexp: "^\tudev_rules = 1"
+    line: "\tudev_rules = 0"

--- a/examples/k8s_v1.13-CSI_v1.0/roles/nodes/tasks/main.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/roles/nodes/tasks/main.yml
@@ -1,0 +1,2 @@
+- name: join with master
+  command: kubeadm join --ignore-preflight-errors=cri --discovery-token-unsafe-skip-ca-verification --token={{ kubernetes_token }} {{ hostvars['master'].ansible_eth1.ipv4.address }}:6443

--- a/examples/k8s_v1.13-CSI_v1.0/setup_csi.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/setup_csi.yml
@@ -1,0 +1,71 @@
+# We need to retry this command, as the API may still be restarting
+- name: Allow Node role to create attachments
+  shell: "kubectl get -o yaml clusterroles/system:node | perl -0pe 's/volumeattachments\n  verbs:\n/volumeattachments\n  verbs:\n  - create\n  - list\n  - update\n  - watch\n  - patch\n  - delete\n/' | kubectl replace -f -"
+  # register: res
+  # until: res | success
+  # retries: 5
+  # delay: 10
+
+- name: Bind master to Node role
+  shell: 'kubectl patch clusterrolebindings/system:node -p ''{"subjects": [{"kind": "User", "name": "system:node:master", "namespace": "kube-system"}]}'''
+
+- name: Bind nodes to Node role
+  shell: "kubectl get -o yaml clusterrolebindings/system:node | perl -0pe 's/subjects:\n/subjects:\n- kind: User\n{{'  '}}name: system:node:{{ item }}\n{{'  '}}namespace: kube-system\n/' | tee -a bind_node.txt | kubectl replace -f -"
+  with_items: "{{ groups['nodes'] }}"
+
+- name: Remove API NodeRestriction
+  lineinfile:
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    regexp: '- --enable-admission-plugins=NodeRestriction'
+    state: absent
+
+# We would normally pass the features-gates to kubeadm init, but it complains
+# about not knowing the features
+# Once we suport CSDriver extra info we should add ,CSIDriverRegistry=true to
+# the feature-gates
+- name: Remove API Node authorization and set required features
+  command: sed -i 's/    - --authorization-mode=Node,RBAC/    - --authorization-mode=RBAC\n    - --feature-gates=CSIBlockVolume=true,VolumeSnapshotDataSource=true,CSINodeInfo=true/' /etc/kubernetes/manifests/kube-apiserver.yaml
+
+- name: Restart API containers
+  shell: docker restart $(docker ps --filter "name=apiserver_kube" --format "{{'{{'}}.ID{{'}}'}}") || true
+
+- name: Restart Scheduler and Manager containers
+  shell: docker restart $(docker ps --filter "name=scheduler_kube|manager_kube" --format "{{'{{'}}.ID{{'}}'}}") || true
+
+- name: Copy YML files
+  copy:
+    src: kubeyml
+    dest: /home/vagrant
+    owner: vagrant
+    group: vagrant
+
+- wait_for: timeout=20
+  delegate_to: localhost
+# We don't support kubernetes CSDriver additional info, so we don't need the CRD yet
+# - name: Create CRD for the CSIDriverRegistry feature
+#   command: kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csidriver.yaml --validate=false
+- name: Create CRD for the CSINodeInfo feature
+  command: kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csinodeinfo.yaml --validate=false
+
+- wait_for: timeout=180
+  delegate_to: localhost
+#- pause: minutes=3
+- name: Set CSI controller
+  command: kubectl create -f /home/vagrant/kubeyml/controller.yml
+
+- wait_for: timeout=180
+  delegate_to: localhost
+#- pause: minutes=3
+
+- name: Start CSI nodes
+  command: kubectl create -f /home/vagrant/kubeyml/node.yml
+
+- name: Create Storage Class
+  command: kubectl create -f /home/vagrant/kubeyml/storage-class.yml
+
+# We need to wait for VolumeSnapshotClass to exist
+- wait_for: timeout=180
+  delegate_to: localhost
+#- pause: minutes=3
+- name: Create Snapshot Storage Class
+  command: kubectl create -f /home/vagrant/kubeyml/snapshot-class.yml

--- a/examples/k8s_v1.13-CSI_v1.0/site.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/site.yml
@@ -1,0 +1,30 @@
+- hosts: all
+  become: yes
+  become_method: sudo
+  vars_files:
+    - "global_vars.yml"
+  roles:
+    - common
+
+- hosts: master_node
+  become: yes
+  become_method: sudo
+  vars_files:
+    - "global_vars.yml"
+  roles:
+    - master
+  environment:
+    KUBECONFIG: '/etc/kubernetes/admin.conf'
+
+- hosts: nodes
+  become: yes
+  become_method: sudo
+  vars_files:
+    - "global_vars.yml"
+  roles:
+    - nodes
+
+- hosts: master_node
+  become: yes
+  tasks:
+    - import_tasks: setup_csi.yml

--- a/examples/k8s_v1.13-CSI_v1.0/up.sh
+++ b/examples/k8s_v1.13-CSI_v1.0/up.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+lhost=${LIBVIRT_HOST:-''}
+luser=${LIBVIRT_USER:-'root'}
+
+LIBVIRT_HOST=$lhost LIBVIRT_USER=$luser vagrant up --provider=libvirt --no-provision $@ \
+    && LIBVIRT_HOST=$lhost LIBVIRT_USER=$luser vagrant provision


### PR DESCRIPTION
This patch adds an example on how to run a Kubernetes cluster v1.13 with
Ember-CSI running CSI v1.0.

Includes examples for snapshots and creating volume from snapshot.