### PR TITLE
Fix image location of k8s v1.13 example

### DIFF
--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/lvm/01-controller.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/lvm/01-controller.yml
@@ -128,8 +128,7 @@ spec:
         - mountPath: /csi-data
           name: socket-dir
       - name: csi-driver
-        # image: embercsi/ember-csi:master
-        image: 192.168.1.11:5000/ember-csi:master
+        image: embercsi/ember-csi:master
         # command: ["tail"]
         # args: ["-f", "/dev/null"]
         imagePullPolicy: Always

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/lvm/02-node.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/lvm/02-node.yml
@@ -87,8 +87,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: csi-driver
-          # image: embercsi/ember-csi:master
-          image: 192.168.1.11:5000/ember-csi:master
+          image: embercsi/ember-csi:master
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
@@ -256,8 +255,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: csi-driver
-          # image: embercsi/ember-csi:master
-          image: 192.168.1.11:5000/ember-csi:master
+          image: embercsi/ember-csi:master
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/rbd/01-controller.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/rbd/01-controller.yml
@@ -126,8 +126,7 @@ spec:
         - mountPath: /csi-data
           name: socket-dir
       - name: csi-driver
-        # image: embercsi/ember-csi:master
-        image: 192.168.1.11:5000/ember-csi:master
+        image: embercsi/ember-csi:master
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/rbd/02-node.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/rbd/02-node.yml
@@ -77,8 +77,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: csi-driver
-          # image: embercsi/ember-csi:master
-          image: 192.168.1.11:5000/ember-csi:master
+          image: embercsi/ember-csi:master
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true


### PR DESCRIPTION
When we updated the Kubernetes example we accidentaly merged it with the
wrong docker images, as they were pointing to a test repository.

This patch changes it back to using dockerhub's repository.