### PR TITLE
Update containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,21 @@
 FROM centos:7
 ARG RELEASE=master
 ARG VERSION=master
+ARG BUILD_DATE
+ARG VCS_REF
+ARG TAG
 
 LABEL maintainers="Gorka Eguileor <geguileo@redhat.com>" \
-      description="Ember CSI Plugin" \
+      openstack_release=${RELEASE} \
       version=${VERSION} \
-      cinderlib_release=${RELEASE}
+      description="Ember CSI Plugin" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.name="ember-csi" \
+      org.label-schema.description="Ember CSI Plugin" \
+      org.label-schema.url="https://ember-csi.io" \
+      org.label-schema.build-date=${BUILD_DATE} \
+      org.label-schema.vcs-url="https://github.com/embercsi/ember-csi" \
+      org.label-schema.vcs-ref=${VCS_REF}
 
 # Enable RPDB debugging on this container by default
 ENV X_CSI_DEBUG_MODE=rpdb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ EXPOSE 50051 4444
 
 # We first check that we have access to the PyPi server
 RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-release lvm2 which && \
-    yum -y install python2-pip pywbem && \
+    yum -y install python2-pip pywbem python2-kubernetes && \
     yum -y install xfsprogs e2fsprogs btrfs-progs nmap-ncat && \
     # We need to upgrade pyasn1 because the package for RDO is not new enough for
     # pyasn1_modules, which is used by some of the Google's libraries
@@ -32,9 +32,9 @@ RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-
     if [ "$RELEASE" = "master" ]; then curl -o /etc/yum.repos.d/rdo-trunk-runtime-deps.repo https://trunk.rdoproject.org/centos7-master/rdo-trunk-runtime-deps.repo; curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos7-master/current/delorean.repo; else yum -y install centos-release-openstack-${RELEASE}; fi && \
     yum -y install python-cinderlib && \
     # Install driver specific RPM dependencies
-    yum -y install python-rbd ceph-common && \
+    yum -y install python-rbd ceph-common pyOpenSSL && \
     # Install driver specific PyPi dependencies
-    pip install --no-cache-dir krest purestorage pyxcli pyOpenSSL && \
+    pip install --no-cache-dir krest purestorage pyxcli && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -33,7 +33,7 @@ RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-
     yum -y install python-cinderlib xfsprogs e2fsprogs btrfs-progs nmap-ncat && \
     # We need to upgrade pyasn1 because the package for RDO is not new enough for
     # pyasn1_modules, which is used by some of the Google's libraries
-    pip install --no-cache-dir --upgrade 'pyasn1<0.5.0,>=0.4.1' future ember-csi && \
+    pip install --no-cache-dir --upgrade 'pyasn1<0.5.0,>=0.4.1' future "ember-csi==${TAG}" && \
     # Install driver specific RPM dependencies
     yum -y install python-rbd ceph-common pyOpenSSL && \
     # Install driver specific PyPi dependencies

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -4,7 +4,7 @@ ARG VERSION=master
 FROM centos:7
 LABEL maintainers="Gorka Eguileor <geguileo@redhat.com>" \
       description="Ember CSI Plugin" \
-      version=${VERSION}
+      version=${VERSION} \
       cinderlib_release=${RELEASE}
 
 # Enable RPDB debugging on this container by default
@@ -20,7 +20,7 @@ RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-
     yum -y install python-cinderlib xfsprogs e2fsprogs btrfs-progs nmap-ncat && \
     # We need to upgrade pyasn1 because the package for RDO is not new enough for
     # pyasn1_modules, which is used by some of the Google's libraries
-    pip install --no-cache-dir --upgrade 'pyasn1<0.5.0,>=0.4.1' future && \
+    pip install --no-cache-dir --upgrade 'pyasn1<0.5.0,>=0.4.1' future ember-csi && \
     # Install driver specific RPM dependencies
     yum -y install python-rbd ceph-common pyOpenSSL && \
     # Install driver specific PyPi dependencies

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,11 +1,24 @@
 ARG RELEASE=master
 ARG VERSION=master
+ARG BUILD_DATE
+ARG VCS_REF
+ARG TAG
+
+org.label-schema.vcs-ref=$VCS_REF \
 
 FROM centos:7
 LABEL maintainers="Gorka Eguileor <geguileo@redhat.com>" \
-      description="Ember CSI Plugin" \
+      openstack_release=${RELEASE} \
       version=${VERSION} \
-      cinderlib_release=${RELEASE}
+      description="Ember CSI Plugin" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.name="ember-csi" \
+      org.label-schema.version=${TAG}  \
+      org.label-schema.description="Ember CSI Plugin" \
+      org.label-schema.url="https://ember-csi.io" \
+      org.label-schema.build-date=${BUILD_DATE} \
+      org.label-schema.vcs-url="https://github.com/embercsi/ember-csi" \
+      org.label-schema.vcs-ref=${VCS_REF}
 
 # Enable RPDB debugging on this container by default
 ENV PYTHONUNBUFFERED=true

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -15,17 +15,16 @@ ENV PYTHONUNBUFFERED=true
 # For the Master version expose RPDB port to support remote debugging
 EXPOSE 50051 4444
 
-# We first check that we have access to the PyPi server
 RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-release lvm2 which && \
-    yum -y install python2-pip pywbem centos-release-openstack-${RELEASE} && \
-    yum -y install cinderlib xfsprogs e2fsprogs btrfs-progs nmap-ncat && \
+    yum -y install python2-pip pywbem python2-kubernetes centos-release-openstack-${RELEASE} && \
+    yum -y install python-cinderlib xfsprogs e2fsprogs btrfs-progs nmap-ncat && \
     # We need to upgrade pyasn1 because the package for RDO is not new enough for
     # pyasn1_modules, which is used by some of the Google's libraries
     pip install --no-cache-dir --upgrade 'pyasn1<0.5.0,>=0.4.1' future && \
     # Install driver specific RPM dependencies
-    yum -y install python-rbd ceph-common && \
+    yum -y install python-rbd ceph-common pyOpenSSL && \
     # Install driver specific PyPi dependencies
-    pip install --no-cache-dir krest purestorage pyxcli pyOpenSSL && \
+    pip install --no-cache-dir krest purestorage pyxcli && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/ci-automation/bootstrap.sh
+++ b/ci-automation/bootstrap.sh
@@ -10,12 +10,10 @@ curl -o /etc/yum.repos.d/delorean.repo https://trunk.rdoproject.org/centos7-mast
 
 PKGS=(epel-release)
 yum install --setopt=skip_missing_names_on_install=False -y "${PKGS[@]}"
-PKGS=(git gcc python-devel lvm2 docker python2-pip e2fsprogs iscsi-initiator-utils python-cinderlib)
+PKGS=(git gcc python-devel lvm2 docker python2-pip e2fsprogs iscsi-initiator-utils python2-kubernetes python-cinderlib)
 yum install --setopt=skip_missing_names_on_install=False -y "${PKGS[@]}"
 
 systemctl start docker.service iscsid.service
 
-# We need to upgrade setuptools to >= 40.0.0 to support 4.* format in requirements
-pip install --upgrade setuptools
 pip install -r $home/requirements_dev.txt
 pip install -e $home/..

--- a/hooks/build
+++ b/hooks/build
@@ -6,13 +6,32 @@ EMBER_VERSION=`git describe --tags`
 if [ "$SOURCE_BRANCH" == "master" ]
 then
   STABLE_RELEASE=`tail -1 hooks/rdo-releases`
-  docker build --build-arg VERSION=$EMBER_VERSION --build-arg RELEASE=master -t $DOCKER_REPO:master -f Dockerfile .
-  docker build --build-arg VERSION=$EMBER_VERSION --build-arg RELEASE=$STABLE_RELEASE -t $DOCKER_REPO:latest -f Dockerfile .
+  docker build \
+         --build-arg RELEASE=master \
+         --build-arg VERSION=$EMBER_VERSION \
+         --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+         --build-arg VCS_REF=`git rev-parse --short HEAD` \
+         -t $DOCKER_REPO:master \
+         -f Dockerfile .
+  docker build \
+         --build-arg RELEASE=$STABLE_RELEASE \
+         --build-arg VERSION=$EMBER_VERSION \
+         --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+         --build-arg VCS_REF=`git rev-parse --short HEAD` \
+         -t $DOCKER_REPO:latest \
+         -f Dockerfile .
 
 else
   RDO_RELEASES=`cat hooks/rdo-releases`
   while read -r release; do
     echo "Building $SOURCE_BRANCH with cinderlib $release ..."
-    docker build --build-arg VERSION=$EMBER_VERSION --build-arg RELEASE=$release --build -t $DOCKER_REPO:$release -f Dockerfile-release .
+    docker build \
+           --build-arg RELEASE=$release \
+           --build-arg VERSION=$EMBER_VERSION \
+           --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+           --build-arg VCS_REF=`git rev-parse --short HEAD` \
+           --build-arg TAG=$SOURCE_BRANCH \
+           --build -t $DOCKER_REPO:$release \
+           -f Dockerfile-release .
   done <<< "$RDO_RELEASES"
 fi

--- a/hooks/build
+++ b/hooks/build
@@ -7,8 +7,7 @@ if [ "$SOURCE_BRANCH" == "master" ]
 then
   STABLE_RELEASE=`tail -1 hooks/rdo-releases`
   docker build --build-arg VERSION=$EMBER_VERSION --build-arg RELEASE=master -t $DOCKER_REPO:master -f Dockerfile .
-  # TODO: Uncomment once we release cinderlib in Stein
-  # docker build --build-arg VERSION=$EMBER_VERSION --build-arg RELEASE=$STABLE_RELEASE -t $DOCKER_REPO:latest -f Dockerfile .
+  docker build --build-arg VERSION=$EMBER_VERSION --build-arg RELEASE=$STABLE_RELEASE -t $DOCKER_REPO:latest -f Dockerfile .
 
 else
   RDO_RELEASES=`cat hooks/rdo-releases`

--- a/hooks/push
+++ b/hooks/push
@@ -4,8 +4,7 @@ set -e
 # Push ember-csi master branches
 if [ "$SOURCE_BRANCH" == "master" ]
 then
-  # TODO: Add latest once we release cinderlib in Stein
-  for tag in master; do
+  for tag in master latest; do
     echo "Pushing $tag ..."
     docker push $DOCKER_REPO:$tag
   done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cinderlib>=0.9.0
 grpcio==1.15.0
 protobuf>=3.5.0.post1
-kubernetes==7.0.0
+kubernetes>=7.0.0
 setuptools>=40.0.0

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,10 @@ requirements = [
     # GRPCIO v1.12.0 has broken dependencies, so we include them here
     'protobuf>=3.5.0.post1',
     # For the CRD persistent metadata plugin
-    'kubernetes==7.0.0',
-    # Needed because some Kubernetes dependencies use version in format of 4.*
-    'setuptools>=40.0.0',
+    'kubernetes>=7.0.0',
+    # If we install from PyPi we needed a newer setuptools because some
+    # Kubernetes dependencies use version in format of 4.*
+    # 'setuptools>=40.0.0',
 ]
 
 dependency_links = [


### PR DESCRIPTION
This PR updates our containers to reduce PyPi package installs and replace them with their RPM counterparts, build the ember-csi:latest container again now that RDO has released Stein, and install ember-csi in the release container.