### PR TITLE
Close #108: Finer grained `vendor_version`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,14 @@ RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-
 
 COPY . /ember-csi
 
-RUN pip install --no-cache-dir -e /ember-csi
+# Add build metadata (date and time when the container was generated) to the
+# version reported by Ember-CSI following semver notation:
+# https://semver.org/#spec-item-10
+# TODO: Maybe use pbr instead of doing it manually
+RUN sed -i -r "s/^(VENDOR_VERSION = ').+'/\1${VERSION}+`date +%d%m%Y%H%M%S%N`'/" /ember-csi/ember_csi/constants.py && \
+    sed -i -r "s/(version=').+'/\1$VERSION+`date +%d%m%Y%H%M%S%N`'/" /ember-csi/setup.py && \
+    sed -i -r "s/^(__version__ = ').*'$/\1${VERSION}+`date +%d%m%Y%H%M%S%N`'/" /ember-csi/ember_csi/__init__.py && \
+    pip install --no-cache-dir -e /ember-csi
 
 # Define default command
 CMD ["ember-csi"]

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -32,6 +32,8 @@ RUN yum -y install --setopt=skip_missing_names_on_install=False targetcli iscsi-
     # We need to upgrade pyasn1 because the package for RDO is not new enough for
     # pyasn1_modules, which is used by some of the Google's libraries
     pip install --no-cache-dir --upgrade 'pyasn1<0.5.0,>=0.4.1' future "ember-csi==${TAG}" && \
+    # Add build metadata (date and time when the container was generated) to the version reported by Ember-CSI following semver notation: https://semver.org/#spec-item-10
+    sed -i -r "s/^(VENDOR_VERSION = ').+'/\1${VERSION}+`date +%d%m%Y%H%M%S%N`'/" /ember-csi/ember_csi/constants.py && \
     # Install driver specific RPM dependencies
     yum -y install --setopt=skip_missing_names_on_install=False python-rbd ceph-common pyOpenSSL && \
     # Install driver specific PyPi dependencies


### PR DESCRIPTION
This patch makes Ember-CSI report a finer grained `vendor_version` in the `GetPluginCapabilities` response.

Reported version will depend on whether it's a release or a build from master.

For build from master it will be reporting the Ember-CSI version, the number of commits since the last release, the short hash, and the date and time of the build as DDMMYYYYhhmmssnnnnnnnnn. For example:  0.9.0-12-gbbce4e1+03092019170848330555972

For releases it will only append the date and time:   0.9.0+03092019170848330555972

All versions reported conform to semver as per https://semver.org/#spec-item-10

For master builds it will also set this version as the Ember-CSI Python package and in `ember_csi.__version__`.