### PR TITLE
Fix #139: Cloning on Kubernetes

### DIFF
--- a/ember_csi/v1_0_0/csi.py
+++ b/ember_csi/v1_0_0/csi.py
@@ -110,7 +110,7 @@ class Controller(base.TopologyBase, base.SnapshotBase, base.ControllerBase):
         #    parameters['content_source'] = request.content_source
         if vol.source_volid:
             parameters['content_source'] = types.VolumeContentSource(
-                volume=types.VolumeSource(volume_id=vol.source_vol_id))
+                volume=types.VolumeSource(volume_id=vol.source_volid))
 
         elif vol.snapshot_id:
             parameters['content_source'] = types.VolumeContentSource(

--- a/patches/apply-patches
+++ b/patches/apply-patches
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ev
+PACKAGES_DIR=${1:-/usr/lib/python2.7/site-packages}
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Use a manual list instead of file listing in case we have a required order
+# Generated to avoid including tests using:
+#   git diff HEAD~1 --no-prefix -- cinderlib/objects.py > filename.patch
+declare -a PATCHES=("cinderlib-bugs-1849339-1849828.patch")
+
+for patch_file in "${PATCHES[@]}"; do
+   echo "Patching $PACKAGES_DIR with $patch_file"
+   PATCH_FILE="$SCRIPT_DIR/$patch_file"
+   # Check if already applied
+   if ! patch -R -p0 -s -f --dry-run -d $PACKAGES_DIR <$PATCH_FILE; then
+     patch -p0 -N --silent -d $PACKAGES_DIR <$PATCH_FILE
+   else
+     echo "Patch already applied, skipping"
+   fi
+done

--- a/patches/cinderlib-bugs-1849339-1849828.patch
+++ b/patches/cinderlib-bugs-1849339-1849828.patch
@@ -1,0 +1,27 @@
+diff --git cinderlib/objects.py cinderlib/objects.py
+index 2586954..ea65f6f 100644
+--- cinderlib/objects.py
++++ cinderlib/objects.py
+@@ -501,18 +501,18 @@ class Volume(NamedObject):
+             self.save()
+ 
+     def clone(self, **new_vol_attrs):
+-        new_vol_attrs['source_vol_id'] = self.id
++        new_vol_attrs['source_volid'] = self.id
+         new_vol = Volume(self, **new_vol_attrs)
+         self.backend._start_creating_volume(new_vol)
+         try:
+             model_update = self.backend.driver.create_cloned_volume(
+                 new_vol._ovo, self._ovo)
+-            new_vol.status = 'available'
++            new_vol._ovo.status = 'available'
+             if model_update:
+-                new_vol.update(model_update)
++                new_vol._ovo.update(model_update)
+             self.backend._volume_created(new_vol)
+         except Exception:
+-            new_vol.status = 'error'
++            new_vol._ovo.status = 'error'
+             new_vol._raise_with_resource()
+         finally:
+             new_vol.save()


### PR DESCRIPTION
The GRPC call to create a volume using another one as source works fine
and creates a cloned volume, but it's not returning the content_source,
so it will pass the csi-sanity tests, but it will fail when running in
Kubernetes because the external-provisioner sidecar expects the field to
be filled.

The reason for the failure is that cinderlib is not setting the right
field when cloning. Instead of setting source_volid it's setting
source_vol_id: https://bugs.launchpad.net/cinderlib/+bug/1849339

There is another cinderlib bug affecting cloning,
https://bugs.launchpad.net/cinderlib/+bug/1849828 that prevents us from
attaching a volume cloned from an attached volume.

As a temporary workaround we will modify the source code ourselves
during installation to fix all these metadata issues.

With this fix we have introduced a new mechanism to run patches when
installing ember-csi in our container.