### PR TITLE
Fix #140: Volume from snap doesn't extend volume

### DIFF
--- a/ember_csi/base.py
+++ b/ember_csi/base.py
@@ -977,7 +977,7 @@ class SnapshotBase(object):
             context.abort(grpc.StatusCode.OUT_OF_RANGE,
                           'Snapshot %s is bigger than requested volume' %
                           snap_id)
-        vol = src_snap.create_volume(name=name, **params)
+        vol = src_snap.create_volume(name=name, size=vol_size, **params)
         return vol
 
     # Inheriting classes must implement


### PR DESCRIPTION
When we create a volume from a snapshot and request that the new volume
has a greater size than the original snapshot the volume ends up with
the same size as the snapshot instead of the requested size.

This patch passes the requested volume size to the snapshot's
create_volume call, as we should have done all along.