### PR TITLE
Fix example

### DIFF
--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/lvm/02-node.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/lvm/02-node.yml
@@ -155,8 +155,10 @@ spec:
             - name: iscsi-info
               mountPath: /var/lib/iscsi
               mountPropagation: Bidirectional
-            # In a real deployment we should be mounting container's
-            # /var/lib-ember-csi on the host
+            # So we don't lose our private bindmounts on container reboot
+            - name: ember-csi-data
+              mountPath: /var/lib/ember-csi
+              mountPropagation: Bidirectional
         - name: csc
           image: embercsi/csc:v1.0.0
           command: ["tail"]
@@ -211,6 +213,9 @@ spec:
         - name: iscsi-info
           hostPath:
             path: /var/lib/iscsi
+        - name: ember-csi-data
+          hostPath:
+            path: /var/lib/ember-csi/lvm
 ---
 # Node 0 cannot access LVM iSCSI backend
 # We need this pod because CSI needs all nodes to be running the plugin
@@ -322,8 +327,10 @@ spec:
             - name: iscsi-info
               mountPath: /var/lib/iscsi
               mountPropagation: Bidirectional
-            # In a real deployment we should be mounting container's
-            # /var/lib-ember-csi on the host
+            # So we don't lose our private bindmounts on container reboot
+            - name: ember-csi-data
+              mountPath: /var/lib/ember-csi
+              mountPropagation: Bidirectional
         - name: csc
           image: embercsi/csc:v1.0.0
           command: ["tail"]
@@ -378,3 +385,6 @@ spec:
         - name: iscsi-info
           hostPath:
             path: /var/lib/iscsi
+        - name: ember-csi-data
+          hostPath:
+            path: /var/lib/ember-csi/lvm

--- a/examples/k8s_v1.13-CSI_v1.0/kubeyml/rbd/02-node.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/kubeyml/rbd/02-node.yml
@@ -126,9 +126,10 @@ spec:
             - name: udev-data
               mountPath: /run/udev
               mountPropagation: HostToContainer
-            # Required to preserve the node targets between restarts
-            # In a real deployment we should be mounting container's
-            # /var/lib-ember-csi on the host
+            # So we don't lose our private bindmounts on container reboot
+            - name: ember-csi-data
+              mountPath: /var/lib/ember-csi
+              mountPropagation: Bidirectional
         - name: csc
           image: embercsi/csc:v1.0.0
           command: ["tail"]
@@ -164,3 +165,6 @@ spec:
         - name: udev-data
           hostPath:
             path: /run/udev
+        - name: ember-csi-data
+          hostPath:
+            path: /var/lib/ember-csi/rbd

--- a/examples/k8s_v1.13-CSI_v1.0/roles/nodes/tasks/main.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/roles/nodes/tasks/main.yml
@@ -1,2 +1,8 @@
+- name: Create ember-csi directory for bind mounts
+  file: path=/var/lib/ember-csi/ state=directory
+
+- file: path=/var/lib/ember-csi/rbd state=directory
+- file: path=/var/lib/ember-csi/lvm state=directory
+
 - name: join with master
   command: kubeadm join --ignore-preflight-errors=cri --discovery-token-unsafe-skip-ca-verification --token={{ kubernetes_token }} {{ hostvars['master'].ansible_eth1.ipv4.address }}:6443

--- a/examples/k8s_v1.13-CSI_v1.0/setup_csi.yml
+++ b/examples/k8s_v1.13-CSI_v1.0/setup_csi.yml
@@ -109,4 +109,4 @@
   delegate_to: localhost
 
 - name: Change Ceph default features
-  command: kubectl exec csi-rbd-0 -c csi-driver -- /bin/bash -c 'echo -e "\nrbd default features = 3" >> /etc/ceph/ceph.conf'
+  command: kubectl exec csi-rbd-0 -c csi-driver -- /bin/bash -c 'sed -i "s/\[global\]/[global]\nrbd default features = 3/" /etc/ceph/ceph.conf'


### PR DESCRIPTION
The Ember-CSI RBD deployment in the Kubernetes example is no longer
working due to changes to the Ceph Demo container.

The deployment in the example also gets broken if we restart the
Ember-CSI Node container, because we lose all our private data.
Fix this and allow restarts.