### PR TITLE
Fix docker image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ RUN yum -y install targetcli iscsi-initiator-utils device-mapper-multipath epel-
     yum -y install python-cinderlib && \
     # Install driver specific RPM dependencies
     yum -y install python-rbd ceph-common pyOpenSSL && \
+    # Required to apply patches
+    yum -y install patch && \
     # Install driver specific PyPi dependencies
     pip install --no-cache-dir krest purestorage pyxcli python-3parclient && \
     yum clean all && \

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -29,11 +29,15 @@ EXPOSE 50051 4444
 RUN yum -y install --setopt=skip_missing_names_on_install=False targetcli iscsi-initiator-utils device-mapper-multipath epel-release lvm2 which && \
     yum -y install --setopt=skip_missing_names_on_install=False python2-pip pywbem python2-kubernetes centos-release-openstack-${RELEASE} && \
     yum -y install --setopt=skip_missing_names_on_install=False python-cinderlib xfsprogs e2fsprogs btrfs-progs nmap-ncat && \
+    # Required to apply patches
+    yum -y install patch && \
     # We need to upgrade pyasn1 because the package for RDO is not new enough for
     # pyasn1_modules, which is used by some of the Google's libraries
     pip install --no-cache-dir --upgrade 'pyasn1<0.5.0,>=0.4.1' future "ember-csi==${TAG}" && \
     # Add build metadata (date and time when the container was generated) to the version reported by Ember-CSI following semver notation: https://semver.org/#spec-item-10
     sed -i -r "s/^(VENDOR_VERSION = ').+'/\1${VERSION}+`date +%d%m%Y%H%M%S%N`'/" /ember-csi/ember_csi/constants.py && \
+    # Remove patch package
+    yum -y remove patch && \
     # Install driver specific RPM dependencies
     yum -y install --setopt=skip_missing_names_on_install=False python-rbd ceph-common pyOpenSSL && \
     # Install driver specific PyPi dependencies


### PR DESCRIPTION
Building docker images works locally and also in the 3rd party CI
systems, but fails in DockerHub.

Reported error is missing patch binary, so we add it on the Dockerfiles
to ensure it is there.