### PR TITLE
Workaround vagrant-libvirt qemu:///session issue

### DIFF
--- a/examples/k8s_v1.13-CSI_v1.0/Vagrantfile
+++ b/examples/k8s_v1.13-CSI_v1.0/Vagrantfile
@@ -25,6 +25,12 @@ Vagrant.configure("2") do |config|
             v.username = $libvirt_user
             v.connect_via_ssh = true
         end
+
+        # private network configuration is not supported by vagrant
+        # when using qemu:///session
+        if v.respond_to?(:qemu_use_session)
+            v.qemu_use_session = false
+        end
     end
 
     # Make kub master

--- a/examples/k8s_v1.16-CSI_v1.1/Vagrantfile.libvirt
+++ b/examples/k8s_v1.16-CSI_v1.1/Vagrantfile.libvirt
@@ -25,6 +25,12 @@ Vagrant.configure("2") do |config|
             v.username = $libvirt_user
             v.connect_via_ssh = true
         end
+
+        # private_network configuration is not supported by vagrant
+        # when using qemu:///session
+        if v.respond_to?(:qemu_use_session)
+            v.qemu_use_session = false
+        end
     end
 
     # Make kub master


### PR DESCRIPTION
On newer Fedora installations, libvirt defaults to using
qemu:///session instead of qemu:///system.

This is not compatible with vagrant-libvirt.  Use
qemu:///system to ensure that deployment succeeds.

This issue is mentioned in Fedora change notes:
https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session