### PR TITLE
Patches for new versions of k8s libs.

### DIFF
--- a/ember_csi/cl_crd.py
+++ b/ember_csi/cl_crd.py
@@ -217,8 +217,7 @@ class CRD(object):
                                                         cls.CRD_VERSION,
                                                         cls.NAMESPACE,
                                                         cls.plural,
-                                                        name,
-                                                        {})
+                                                        name)
         except k8s.client.rest.ApiException as exc:
             if exc.status != 404:
                 raise

--- a/patches/apply-patches
+++ b/patches/apply-patches
@@ -17,3 +17,4 @@ for patch_file in "${PATCHES[@]}"; do
      echo -e "\tPatch already applied, skipping"
    fi
 done
+echo "Done Applying Patches"

--- a/patches/apply-patches
+++ b/patches/apply-patches
@@ -5,11 +5,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Use a manual list instead of file listing in case we have a required order
 # Generated to avoid including tests using:
 #   git diff HEAD~1 --no-prefix -- cinderlib/objects.py > filename.patch
-declare -a PATCHES=("cinderlib-bugs-1849339-1849828.patch"
-                    "cinderlib-bug-1852629.patch"
-                    "cinderlib-extend-rbd.patch"
-                    "cinderlib-bug-1856556.patch"
-                    "cinderlib-bug-1873312.patch")
+declare -a PATCHES=()
 
 for patch_file in "${PATCHES[@]}"; do
    PATCH_FILE="$SCRIPT_DIR/$patch_file"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ cinderlib>=0.9.0
 grpcio>=1.15.0;python_version!='2.7'
 grpcio==1.15.0;python_version=='2.7'
 protobuf>=3.5.0.post1
-kubernetes>=7.0.0
+kubernetes>=11.0.0,<12.0.0
 setuptools>=40.0.0
 future;python_version<"3.0"

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ requirements = [
     # GRPCIO v1.12.0 has broken dependencies, so we include them here
     'protobuf>=3.5.0.post1',
     # For the CRD persistent metadata plugin
-    'kubernetes>=7.0.0',
+    'kubernetes>=11.0.0,<12.0.0',
     # If we install from PyPi we needed a newer setuptools because some
     # Kubernetes dependencies use version in format of 4.*
     # 'setuptools>=40.0.0',


### PR DESCRIPTION
This pull request changes the minimum version of the kubernetes library to 11.0 which is the latest provided by both centos rpm when for centos7/python27 and by pip from centos8/python36.  The argument definition changed from python-kubernetes v9 to v11 removing body as an argument.  An alternative to the solution in this PR could be to add body as a keyword argument (ember_csi/cl_crd.py#L221 -> body={}) but I did not test this.

This pull request also changes the patch script for compatibility with updated libs in python3.6 since the requirements only set minimum versions the script fails when a newer version of patched lib is used. 
