### PR TITLE
Pure ISCSI and FC drivers validated

### DIFF
--- a/docs/ember.rst
+++ b/docs/ember.rst
@@ -48,6 +48,8 @@ Ember-CSI includes a good number of storage drivers, but due to limitation on ha
 - LVMVolume
 - PowerMaxFC
 - PowerMaxISCSI
+- PureFC
+- PureISCSI
 - QnapISCSI
 - RBD
 - SolidFire
@@ -88,8 +90,6 @@ The remaining drivers included in Ember-CSI have not been validated yet:
 - NetAppCmodeISCSI
 - NexentaISCSI
 - PSSeriesISCSI
-- PureFC
-- PureISCSI
 - Quobyte
 - RSD
 - SCFC


### PR DESCRIPTION
Both Pure ISCSI and FC drivers have been tested under Ember in k8s 1.17 and higher.

These both work successfully and will all expected features.

Moving both drivers to the Supported Drivers section of the docs.