### PR TITLE
Switch to stable API extensions version

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,8 +12,8 @@ Ember-CSI has the following requirements:
   - Fedora
 
 - Container Orchestrator: Both Kubernetes and OpenShift are supported:
-  - Openshift: Recommended version 4.4 or newer. Supported from version 3.10 onward.
-  - Kubernetes: Recommended version 1.17 or newer. Supported from version 1.11 onward.
+  - Openshift: Recommended version 4.6 or newer. Supported from version 4.3 onward.
+  - Kubernetes: Recommended version 1.17 or newer. Supported from version 1.16 onward.
 
 - Storage solution: Access and credentials to a `supported storage solution <index.html#supported_drivers>`_.
 

--- a/ember_csi/cl_crd.py
+++ b/ember_csi/cl_crd.py
@@ -133,11 +133,21 @@ class CRD(object):
 
         As well as with the individual names and shortcuts.
         """
-        crd = {'apiVersion': 'apiextensions.k8s.io/v1beta1',
+        crd = {'apiVersion': 'apiextensions.k8s.io/v1',
                'kind': 'CustomResourceDefinition',
                'metadata': {'name': cls.api_name},
                'spec': {'group': cls.DOMAIN,
-                        'version': cls.CRD_VERSION,
+                        'versions': [{
+                            'name': cls.CRD_VERSION,
+                            'served': True,
+                            'storage': True,
+                            'schema': {
+                                'openAPIV3Schema': {
+                                    'type': 'object',
+                                    'x-kubernetes-preserve-unknown-fields': True
+                                }
+                            }
+                        }],
                         'scope': 'Namespaced',
                         'names': {'kind': cls.kind,
                                   'singular': cls.singular,
@@ -473,11 +483,11 @@ class K8sConnection(object):
             k8s.config.load_incluster_config()
         else:
             k8s.config.load_kube_config()
-        config = k8s.client.Configuration()
+        config = k8s.client.Configuration().get_default_copy()
         if config.host.startswith('https://'):
             config.assert_hostname = False
         self.api = k8s.client.api_client.ApiClient(configuration=config)
-        self.ext_api = k8s.client.ApiextensionsV1beta1Api(self.api)
+        self.ext_api = k8s.client.ApiextensionsV1Api(self.api)
         self.crd_api = k8s.client.CustomObjectsApi(self.api)
 
 

--- a/ember_csi/workarounds.py
+++ b/ember_csi/workarounds.py
@@ -132,7 +132,7 @@ def k8s_issue_376():
 
     That issue will raise a ValueError when creating a CRD because the status
     returned by Kubernetes is set to None, which according to
-    V1beta1CustomResourceDefinitionStatus cannot be.
+    V1CustomResourceDefinitionStatus cannot be.
 
         u'status': {u'acceptedNames': {u'kind': u'', u'plural': u''},
                     u'conditions': None}}
@@ -143,7 +143,7 @@ def k8s_issue_376():
         # Unlike the original one we accept None values
         self._conditions = conditions
 
-    crd_status = k8s.client.models.v1beta1_custom_resource_definition_status
-    crd_status_cls = crd_status.V1beta1CustomResourceDefinitionStatus
+    crd_status = k8s.client.models.v1_custom_resource_definition_status
+    crd_status_cls = crd_status.V1CustomResourceDefinitionStatus
     setattr(crd_status_cls, 'conditions',
             property(fget=crd_status_cls.conditions.fget, fset=set_conditions))

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ requirements = [
     # GRPCIO v1.12.0 has broken dependencies, so we include them here
     'protobuf>=3.5.0.post1',
     # For the CRD persistent metadata plugin
-    'kubernetes>=7.0.0,<12.0.0',
+    'kubernetes>=12.0.0,<13.0.0.',
     # If we install from PyPi we needed a newer setuptools because some
     # Kubernetes dependencies use version in format of 4.*
     # 'setuptools>=40.0.0',


### PR DESCRIPTION
This patch adds compatibility to k8s v1.22 / OpenShift 4.9.

In V1.22, apiextensions.k8s.io/v1beta1 is no longer available [1].
apiextensions.k8s.io/v1 requires a new versions field, thus
extending the current CRD definition [2].

python-kubernetes starts supporting these in 12.0, thus increasing the
dependency as well.

[1] https://kubernetes.io/docs/reference/using-api/deprecation-guide/
[2] https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/